### PR TITLE
Disguise QUIC handshake as HTTP/3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Rusnel is a single-binary TCP/UDP tunneling tool over QUIC. The binary runs as e
 
 ### Core Flow
 
-1. **QUIC transport** (`src/common/quic.rs`): Server generates a self-signed TLS cert at startup. Client skips server cert verification (intentional — proper verification is a TODO). Both use `quinn` with ALPN `hq-29`.
+1. **QUIC transport** (`src/common/quic.rs`): Server generates a self-signed TLS cert at startup. Client skips server cert verification (intentional — proper verification is a TODO). Both use `quinn` with ALPN `h3` (to blend in with HTTP/3 traffic; we don't actually speak HTTP/3).
 
 2. **Remote negotiation** (`src/common/tunnel.rs`): Each tunnel starts with the client opening a QUIC bi-directional stream, sending a JSON-serialized `RemoteRequest`, and receiving a `RemoteResponse`. The server validates the request (e.g., rejects reverse remotes unless `--allow-reverse`).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "rusnel"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "rusnel"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusnel"
 description = "Rusnel is a fast TCP/UDP tunnel, transported over and encrypted using QUIC protocol. Single executable including both client and server"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/guyte149/Rusnel"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -20,12 +20,12 @@ pub fn run(config: ClientConfig) -> Result<()> {
 pub async fn run_async(config: ClientConfig) -> Result<()> {
     let endpoint = create_client_endpoint(&config.tls)?;
 
-    let server_name = client_server_name(&config.tls);
+    let server_name = client_server_name(&config.tls, &config.server.host);
     info!(
         "connecting to server at: {} (sni: {})",
         config.server, server_name
     );
-    let connection_result = endpoint.connect(config.server, &server_name)?.await;
+    let connection_result = endpoint.connect(config.server.addr, &server_name)?.await;
 
     let connection = match connection_result {
         Ok(conn) => {

--- a/src/common/quic.rs
+++ b/src/common/quic.rs
@@ -13,7 +13,11 @@ use tracing::{debug, info, warn};
 
 use crate::common::tls::{cert_sha256, format_fingerprint, ClientTlsConfig, ServerTlsConfig};
 
-static ALPN_QUIC_HTTP: &[&[u8]] = &[b"hq-29"]; // TODO: change to h3
+// Use the HTTP/3 ALPN identifier so handshake fingerprints look like a real
+// QUIC HTTP/3 service. We don't actually speak HTTP/3 — once the TLS handshake
+// completes we tunnel arbitrary streams over QUIC — but advertising `h3` makes
+// passive observers and DPI middleboxes far less likely to flag the traffic.
+static ALPN_QUIC_HTTP: &[&[u8]] = &[b"h3"];
 
 pub fn create_server_endpoint(host: IpAddr, port: u16, tls: &ServerTlsConfig) -> Result<Endpoint> {
     let addr: SocketAddr = SocketAddr::new(host, port);
@@ -246,19 +250,34 @@ fn build_quic_client_config(tls: &ClientTlsConfig) -> Result<ClientConfig> {
     )?)))
 }
 
-/// The SNI / `ServerName` value to use when calling `Endpoint::connect`. For
-/// `Fingerprint` mode we ignore the name during verification, but rustls still
-/// requires a parseable name to send in the ClientHello. For other modes the
-/// name affects verification, so the user can override it via
-/// `--tls-server-name`. Falls back to a placeholder so existing
-/// `Insecure`-mode invocations keep working.
-pub fn client_server_name(tls: &ClientTlsConfig) -> String {
+/// The SNI / `ServerName` value to use when calling `Endpoint::connect`.
+///
+/// Resolution order:
+/// 1. An explicit `--tls-server-name` (or embedded `EMBED_SERVER_NAME`) wins
+///    in every mode that supports it (`Fingerprint`, `Ca`, `Mtls`).
+/// 2. Otherwise we fall back to `server_host` — the host string the user
+///    typed on the CLI (e.g. `example.com` from `example.com:8080`). When
+///    that's a DNS name, it goes on the wire as the SNI extension; when it's
+///    an IP literal, rustls automatically suppresses the SNI extension per
+///    RFC 6066 §3, which is also what real HTTPS clients do.
+///
+/// Using the original hostname as the default is a deliberate choice for the
+/// HTTP/3 disguise goal: a passive observer sees `SNI=example.com` instead of
+/// a static `SNI=rusnel` placeholder that fingerprinted the protocol.
+///
+/// For `Fingerprint` mode the name is ignored during verification (we only
+/// match the leaf cert SHA-256), so any value is safe. For `Ca` / `Mtls`
+/// modes the SNI must match a SAN in the server certificate; the previous
+/// `"rusnel"` fallback effectively required the user to pass
+/// `--tls-server-name`, whereas the new default works automatically when the
+/// cert is issued for the hostname the client connects to.
+pub fn client_server_name(tls: &ClientTlsConfig, server_host: &str) -> String {
     match tls {
-        ClientTlsConfig::Insecure => "rusnel".to_string(),
+        ClientTlsConfig::Insecure => server_host.to_string(),
         ClientTlsConfig::Fingerprint { server_name, .. }
         | ClientTlsConfig::Ca { server_name, .. }
         | ClientTlsConfig::Mtls { server_name, .. } => {
-            server_name.clone().unwrap_or_else(|| "rusnel".to_string())
+            server_name.clone().unwrap_or_else(|| server_host.to_string())
         }
     }
 }

--- a/src/common/quic.rs
+++ b/src/common/quic.rs
@@ -276,9 +276,9 @@ pub fn client_server_name(tls: &ClientTlsConfig, server_host: &str) -> String {
         ClientTlsConfig::Insecure => server_host.to_string(),
         ClientTlsConfig::Fingerprint { server_name, .. }
         | ClientTlsConfig::Ca { server_name, .. }
-        | ClientTlsConfig::Mtls { server_name, .. } => {
-            server_name.clone().unwrap_or_else(|| server_host.to_string())
-        }
+        | ClientTlsConfig::Mtls { server_name, .. } => server_name
+            .clone()
+            .unwrap_or_else(|| server_host.to_string()),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 use common::remote::RemoteRequest;
 use common::tls::{ClientTlsConfig, ServerTlsConfig};
+use std::fmt;
 use std::net::{IpAddr, SocketAddr};
 use tracing::{error, info};
 
@@ -19,9 +20,33 @@ pub struct ServerConfig {
     pub tls: ServerTlsConfig,
 }
 
+/// The server address the client was asked to connect to. Carries both the
+/// resolved `SocketAddr` (used for the actual UDP connect) and the original
+/// host string from the CLI (used as the default SNI value during the TLS
+/// handshake — see `client_server_name`). Keeping the raw host around lets us
+/// send a realistic SNI when the user passed a domain name, instead of a
+/// hard-coded placeholder that fingerprints the protocol.
+#[derive(Debug, Clone)]
+pub struct ServerEndpoint {
+    pub addr: SocketAddr,
+    /// The host portion of the input as the user typed it: a DNS name (e.g.
+    /// `example.com`), an IPv4 literal, or an IPv6 literal without brackets.
+    pub host: String,
+}
+
+impl fmt::Display for ServerEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.host == self.addr.ip().to_string() {
+            write!(f, "{}", self.addr)
+        } else {
+            write!(f, "{} ({})", self.host, self.addr)
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct ClientConfig {
-    pub server: SocketAddr,
+    pub server: ServerEndpoint,
     pub remotes: Vec<RemoteRequest>,
     pub tls: ClientTlsConfig,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,20 +5,41 @@ use rusnel::cert;
 use rusnel::common::remote::RemoteRequest;
 use rusnel::common::tls::{parse_fingerprint, ClientTlsConfig, ServerTlsConfig};
 use rusnel::embedded::{self, Materialized};
-use rusnel::{run_client, run_server, ClientConfig, ServerConfig};
-use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+use rusnel::{run_client, run_server, ClientConfig, ServerConfig, ServerEndpoint};
+use std::net::{IpAddr, ToSocketAddrs};
 use std::path::PathBuf;
 use std::str::FromStr;
 use tracing::{debug, info};
 
-/// Resolve `host:port` to a `SocketAddr`. Used as a clap `value_parser` so
-/// resolution failures surface as `clap::Error` (consistent formatting +
-/// exit code 2) instead of a panic (#20 §4).
-fn parse_server_addr(s: &str) -> Result<SocketAddr, String> {
-    s.to_socket_addrs()
+/// Resolve `host:port` to a `ServerEndpoint`, preserving the original host
+/// string so it can be reused as the TLS SNI value (see `client_server_name`).
+/// Used as a clap `value_parser` so resolution failures surface as a
+/// `clap::Error` (consistent formatting + exit code 2) instead of a panic
+/// (#20 §4).
+fn parse_server_addr(s: &str) -> Result<ServerEndpoint, String> {
+    // Split host:port without losing the host. We do this manually instead of
+    // relying on `SocketAddr::from_str` because we want to accept DNS names
+    // too, not just IP literals.
+    let host = if let Some(rest) = s.strip_prefix('[') {
+        // IPv6 literal form: `[addr]:port`.
+        let close = rest
+            .find(']')
+            .ok_or_else(|| format!("malformed IPv6 address in `{s}` (missing `]`)"))?;
+        rest[..close].to_string()
+    } else {
+        s.rsplit_once(':')
+            .ok_or_else(|| format!("expected host:port in `{s}`"))?
+            .0
+            .to_string()
+    };
+
+    let addr = s
+        .to_socket_addrs()
         .map_err(|e| format!("failed to resolve server address `{s}`: {e}"))?
         .next()
-        .ok_or_else(|| format!("no addresses found for server `{s}`"))
+        .ok_or_else(|| format!("no addresses found for server `{s}`"))?;
+
+    Ok(ServerEndpoint { addr, host })
 }
 
 /// Parse a remote spec via `RemoteRequest::from_str`, surfacing parse errors
@@ -107,7 +128,7 @@ enum Mode {
     Client {
         /// defines the Rusnel server address (in form of host:port)
         #[arg(value_parser = parse_server_addr)]
-        server: SocketAddr,
+        server: ServerEndpoint,
 
         #[arg(name = "remote", required = true, value_parser = parse_remote, value_delimiter = ' ', num_args = 1.., help=r#"
 <remote>s are remote connections tunneled through the server, each which come in the form:

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 use rusnel::common::remote::RemoteRequest;
 use rusnel::common::tls::{ClientTlsConfig, ServerTlsConfig};
-use rusnel::{ClientConfig, ServerConfig};
+use rusnel::{ClientConfig, ServerConfig, ServerEndpoint};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
@@ -70,8 +70,12 @@ pub fn client_config_with_tls(
     remotes: Vec<RemoteRequest>,
     tls: ClientTlsConfig,
 ) -> ClientConfig {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), server_port);
     ClientConfig {
-        server: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), server_port),
+        server: ServerEndpoint {
+            addr,
+            host: addr.ip().to_string(),
+        },
         remotes,
         tls,
     }


### PR DESCRIPTION
Two changes that make the client's QUIC ClientHello blend in with real HTTP/3 traffic instead of fingerprinting the protocol:

- ALPN switched from `hq-29` (a long-deprecated QUIC draft identifier) to `h3` (RFC 9114 HTTP/3). We still tunnel arbitrary streams; only the ALPN advertisement changes.
- Default SNI now reuses the host string the user passed on the CLI (e.g. `example.com` from `example.com:8080`) instead of a hard-coded `rusnel` placeholder. For IP literals rustls suppresses the SNI extension per RFC 6066 §3, matching real client behavior. `--tls-server-name` still wins when set. As a side benefit, `--tls-ca` / `--tls-mtls` modes now work without `--tls-server-name` when the cert's SAN matches the connect hostname.

Plumbed via a new `ServerEndpoint { addr, host }` struct that preserves the original host alongside the resolved `SocketAddr`.

