### PR TITLE
Cleanup pass: hardening, IPv6, and dispatch flattening (v0.3.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,88 @@ All notable changes to this project are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8] - 2026-05-03
+
+Small cleanup release: low-risk wins from the open code-quality and
+security review issues (#17, #19, #22).
+
+### Added
+
+- IPv6 remote support, end to end. Address strings now accept bracketed
+  IPv6 literals anywhere a host can appear:
+  - `[::1]:80` — bind on the IPv4 wildcard, forward to `::1:80`.
+  - `8080:[2001:db8::1]:443` — local IPv4 port, IPv6 upstream.
+  - `[::1]:5000:[2001:db8::1]:80/udp` — full IPv6 quadruple.
+  - `[::1]:1080:socks` and `R:[::1]:5000:[2001:db8::1]:80` — SOCKS and
+    reverse variants.
+  Bracketing is required (same convention as URLs and `ssh -L`) so the
+  parser can tell `[::1]:80` apart from a colon-separated quadruple.
+  The TCP/UDP/SOCKS listen paths now use `SocketAddr::new(local_host,
+  local_port)` to bind, which renders IPv6 correctly as `[::1]:port`,
+  and the UDP server binds the upstream socket in the matching family
+  (`[::]:0` vs `0.0.0.0:0`) so IPv6 targets don't fail with
+  `AddressFamilyNotSupported`. New helpers `RemoteRequest::is_socks`,
+  `local_socket_addr`, and `remote_addr_string` centralize the
+  formatting. Closes #19 §5.
+- New `tests/ipv6.rs` integration suite — TCP and UDP echo over a
+  tunneled `[::1]:port:[::1]:port` remote — and 10 new unit tests in
+  `src/common/remote.rs` covering the bracket tokenizer, every IPv6
+  shape (host:port, local_port:remote, full quadruple, socks, reverse,
+  unbracketed → still rejected, mismatched/missing brackets).
+- 15 unit tests (already shipped earlier in this release) for
+  `RemoteRequest::from_str` covering every documented IPv4 format and
+  the rejection paths. Closes the highest-ROI gap from #22 §7.
+
+### Changed
+
+- QUIC `TransportConfig` now sets `max_idle_timeout = 30 s`,
+  `max_concurrent_bidi_streams = 1024`, and
+  `max_concurrent_uni_streams = 0` on both ends. Previously these were
+  left at quinn's defaults — no idle timeout, unlimited streams —
+  meaning a single peer could open arbitrary numbers of streams (one
+  tunnel task each) and a half-open peer (network drop, hard kill, or
+  attacker) would sit in the connection table indefinitely. Together
+  with the existing 15 s `keep_alive_interval`, a silent peer is now
+  reaped after at most two missed keep-alives. Addresses the DoS
+  exposure noted in #17 §3.
+- `Protocol` now derives `Copy` (and `PartialEq`/`Eq`) so it stops
+  forcing `.clone()` on every dispatch site (#22 §8).
+- The two UDP pump loops are now standalone `async fn` helpers
+  (`pump_socket_to_stream` / `pump_stream_to_socket`) instead of inline
+  `async move` blocks ending in an unreachable `Ok(())`. The four
+  `#[allow(unreachable_code)]` markers in `src/common/udp.rs` are gone:
+  with a proper return type the never-terminating `loop {}` cleanly
+  coerces to `Result<()>` via `!` (#22 §5).
+
+### Fixed
+
+- Typo in client-side error log: `"an error occured"` → `"an error
+  occurred"` (#22 §3).
+
+### Removed
+
+- Unused `RemoteRequest::new` constructor; the two SOCKS handshake call
+  sites now use struct-init syntax directly (#22 §5).
+- `server::run` and `client::run` synchronous wrappers — both built a
+  fresh tokio runtime per call, which was a footgun for embedders
+  (`run` inside an async context = panic). The runtime is now built
+  once at the binary entry point in `lib::run_server` /
+  `lib::run_client`, and `server::run_async` / `client::run_async` are
+  the canonical async entry points (which is what the integration
+  tests already use). Addresses #19 §3.
+
+### Internal
+
+- New `RemoteRequest::is_socks()` helper centralizes the
+  `remote_host == "socks" && remote_port == 0` sentinel check that
+  used to be open-coded at every dispatch site. The dispatchers in
+  `server/mod.rs` and `client/mod.rs` are also flattened: the six-field
+  `RemoteRequest { _, _, _, _, reversed, protocol }` match arms with
+  every field as `_` are replaced by a small `match (reversed,
+  protocol)`. Net ~80 lines deleted, and the dispatch is now exhaustive
+  without `_` placeholders. Partial fix for #19 §1 / #22 §1; the wire
+  format is unchanged.
+
 ## [0.3.7] - 2026-04-30
 
 Reliability & UX release. The client no longer dies on the first

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "rusnel"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusnel"
 description = "Rusnel is a fast TCP/UDP tunnel, transported over and encrypted using QUIC protocol. Single executable including both client and server"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/guyte149/Rusnel"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ Arguments:
                        R:socks
                        R:5000:socks
                        1.1.1.1:53/udp
+                       [::1]:80
+                       [::1]:5000:[2001:db8::1]:80
+                       R:[::1]:2222:[::1]:22
+
+                   IPv6 literals must be wrapped in [brackets] so the parser
+                   can disambiguate them from the colon-separated address
+                   format (same convention as URLs and ssh -L).
 
                    When the Rusnel server has --allow-reverse enabled, remotes can be prefixed with R to denote that they are reversed.
 
@@ -149,27 +156,6 @@ servers reachable via a v6-preferring resolver still connect within
 ~250 ms. Server-side resources (including reverse-tunnel listeners) are
 released the moment the QUIC connection drops.
 
-## Performance
-
-Rusnel (QUIC) vs [Chisel](https://github.com/jpillora/chisel) (SSH-over-WebSocket)
-on loopback. Throughput is iperf3 over a tunneled TCP forward
-(100 MB × 5 runs + warmup, median); latency is the round-trip time of a
-64 B echo across the tunnel.
-
-![Throughput](benchmark/iperf/results/loopback/throughput.png)
-![Latency](benchmark/iperf/results/loopback/latency.png)
-
-End-to-end HTTP request times through the tunnel across payload sizes
-(median of 5 runs, error bars show min/max):
-
-![HTTP through tunnel](benchmark/chisel-bench/results/loopback/chisel-bench.png)
-
-The benchmark harness also includes a `wan` profile that applies
-`tc qdisc netem delay 25ms` to the loopback interface to approximate a
-50 ms-RTT WAN. Reproduce everything with `./benchmark/run.sh`
-(requires Docker; needs `--cap-add=NET_ADMIN` for netem profiles, which
-the script adds for you). See [`benchmark/`](benchmark/) for tunables.
-
 ## Authentication
 
 Both the server and the client require an explicit TLS-mode flag — there is
@@ -204,6 +190,27 @@ rusnel client --tls-ca   ./pki/ca.pem --tls-cert ./pki/client.pem --tls-key ./pk
 credentials baked in at compile time are also supported via
 `RUSNEL_EMBED_*` env vars — see `build.rs` and the
 [CHANGELOG](CHANGELOG.md) for details.
+
+## Performance
+
+Rusnel (QUIC) vs [Chisel](https://github.com/jpillora/chisel) (SSH-over-WebSocket)
+on loopback. Throughput is iperf3 over a tunneled TCP forward
+(100 MB × 5 runs + warmup, median); latency is the round-trip time of a
+64 B echo across the tunnel.
+
+![Throughput](benchmark/iperf/results/loopback/throughput.png)
+![Latency](benchmark/iperf/results/loopback/latency.png)
+
+End-to-end HTTP request times through the tunnel across payload sizes
+(median of 5 runs, error bars show min/max):
+
+![HTTP through tunnel](benchmark/chisel-bench/results/loopback/chisel-bench.png)
+
+The benchmark harness also includes a `wan` profile that applies
+`tc qdisc netem delay 25ms` to the loopback interface to approximate a
+50 ms-RTT WAN. Reproduce everything with `./benchmark/run.sh`
+(requires Docker; needs `--cap-add=NET_ADMIN` for netem profiles, which
+the script adds for you). See [`benchmark/`](benchmark/) for tunables.
 
 ## TODO
 - [x] write tests in rust for tcp, udp, reverse and socks

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -17,10 +17,6 @@ use crate::common::tunnel::{client_send_remote_request, server_receive_remote_re
 use crate::common::udp::{tunnel_udp_client, tunnel_udp_server};
 use crate::{ClientConfig, ReconnectConfig};
 
-pub fn run(config: ClientConfig) -> Result<()> {
-    tokio::runtime::Runtime::new()?.block_on(run_async(config))
-}
-
 pub async fn run_async(config: ClientConfig) -> Result<()> {
     let mut endpoints = EndpointPool::new(&config)?;
     let server_name = client_server_name(&config.tls, &config.server.host);
@@ -336,56 +332,24 @@ async fn run_session(
 }
 
 async fn handle_remote_stream(quic_connection: Connection, remote: RemoteRequest) -> Result<()> {
-    match remote {
-        // socks
-        RemoteRequest {
-            local_host: _,
-            local_port: _,
-            remote_host: ref remote_host_ref,
-            remote_port: 0,
-            reversed: false,
-            protocol: Protocol::Tcp,
-        } if remote_host_ref == "socks" => {
-            tunnel_socks_client(quic_connection, remote).await?;
-        }
+    // Reverse remotes only register interest with the server here — actual
+    // tunnel data flows back through `client_accept_dynamic_reverse_remote`
+    // when the server opens a stream for an inbound connection.
+    if remote.reversed {
+        let (mut send, mut recv) = quic_connection.open_bi().await?;
+        client_send_remote_request(&remote, &mut send, &mut recv).await?;
+        send.shutdown().await?;
+        return Ok(());
+    }
 
-        // simple forward TCP
-        RemoteRequest {
-            local_host: _,
-            local_port: _,
-            remote_host: _,
-            remote_port: _,
-            reversed: false,
-            protocol: Protocol::Tcp,
-        } => {
-            tunnel_tcp_client(quic_connection, remote).await?;
-        }
+    if remote.is_socks() {
+        tunnel_socks_client(quic_connection, remote).await?;
+        return Ok(());
+    }
 
-        // simple forward UDP
-        RemoteRequest {
-            local_host: _,
-            local_port: _,
-            remote_host: _,
-            remote_port: _,
-            reversed: false,
-            protocol: Protocol::Udp,
-        } => {
-            tunnel_udp_client(quic_connection, remote).await?;
-        }
-
-        // reverse remote
-        RemoteRequest {
-            local_host: _,
-            local_port: _,
-            remote_host: _,
-            remote_port: _,
-            reversed: true,
-            protocol: _,
-        } => {
-            let (mut send, mut recv) = quic_connection.open_bi().await?;
-            client_send_remote_request(&remote, &mut send, &mut recv).await?;
-            send.shutdown().await? // finish - the main loop will get a dynamic remote connection
-        }
+    match remote.protocol {
+        Protocol::Tcp => tunnel_tcp_client(quic_connection, remote).await?,
+        Protocol::Udp => tunnel_udp_client(quic_connection, remote).await?,
     }
     Ok(())
 }

--- a/src/common/quic.rs
+++ b/src/common/quic.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context, Result};
 use quinn::congestion::BbrConfig;
 use quinn::crypto::rustls::{QuicClientConfig, QuicServerConfig};
 use quinn::{ClientConfig, Endpoint};
-use quinn::{ServerConfig, TransportConfig, VarInt};
+use quinn::{IdleTimeout, ServerConfig, TransportConfig, VarInt};
 use rcgen::generate_simple_self_signed;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName, UnixTime};
 use rustls::{ClientConfig as TlsClientConfig, ServerConfig as TlsServerConfig};
@@ -51,10 +51,27 @@ pub enum Congestion {
 /// the default.
 fn build_transport_config(congestion: Congestion) -> Arc<TransportConfig> {
     let mut tc = TransportConfig::default();
+    // 30 s idle timeout pairs with the 15 s keep-alive: a peer that goes
+    // silent (network drop, hard kill) is reaped after at most two missed
+    // keep-alives instead of relying on quinn's default of "never time out".
+    // Without this the server-side connection table grows unboundedly under
+    // half-open connections — a trivial DoS vector noted in #17 §3.
+    let idle_timeout = IdleTimeout::try_from(Duration::from_secs(30))
+        .expect("30s fits in QUIC idle-timeout VarInt");
+    // Cap concurrent streams per QUIC connection. Without a cap a single
+    // peer can open unlimited bi-streams (one accept_bi() per stream → one
+    // tunnel task), which is a trivial memory / fd DoS vector noted in
+    // #17 §3. 1024 is well above any legitimate use (each tunnel is at most
+    // one stream; each SOCKS connection is one stream) and still bounds
+    // worst-case resource use. We never open uni-streams, so cap them at 0
+    // to fail-fast if a future change accidentally opens one.
     tc.stream_receive_window(VarInt::from_u32(16 * 1024 * 1024))
         .receive_window(VarInt::from_u32(64 * 1024 * 1024))
         .send_window(64 * 1024 * 1024)
-        .keep_alive_interval(Some(Duration::from_secs(15)));
+        .keep_alive_interval(Some(Duration::from_secs(15)))
+        .max_idle_timeout(Some(idle_timeout))
+        .max_concurrent_bidi_streams(VarInt::from_u32(1024))
+        .max_concurrent_uni_streams(VarInt::from_u32(0));
     if let Congestion::Bbr = congestion {
         tc.congestion_controller_factory(Arc::new(BbrConfig::default()));
     }

--- a/src/common/remote.rs
+++ b/src/common/remote.rs
@@ -2,9 +2,10 @@ use crate::common::utils::SerdeHelper;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::net::{Ipv6Addr, SocketAddr};
 use std::{net::IpAddr, str::FromStr};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Protocol {
     Tcp,
     Udp,
@@ -20,23 +21,97 @@ pub struct RemoteRequest {
     pub protocol: Protocol,
 }
 
+/// Marker the parser writes into `remote_host` to denote "this remote is a
+/// SOCKS5 dynamic tunnel". Kept as a constant so the magic string isn't
+/// duplicated across dispatch sites and tests. The struct still carries the
+/// sentinel directly because the wire format is shared between client and
+/// server and a layout change would be a breaking protocol change.
+const SOCKS_SENTINEL_HOST: &str = "socks";
+
 impl RemoteRequest {
-    pub fn new(
-        local_host: IpAddr,
-        local_port: u16,
-        remote_host: String,
-        remote_port: u16,
-        reversed: bool,
-        protocol: Protocol,
-    ) -> RemoteRequest {
-        RemoteRequest {
-            local_host,
-            local_port,
-            remote_host,
-            remote_port,
-            reversed,
-            protocol,
+    /// `true` if this remote is a SOCKS5 dynamic tunnel (e.g. `socks`,
+    /// `5000:socks`, `R:socks`). Centralizes the historical
+    /// `remote_host == "socks" && remote_port == 0` check that used to be
+    /// open-coded in every dispatch site.
+    pub fn is_socks(&self) -> bool {
+        self.remote_host == SOCKS_SENTINEL_HOST && self.remote_port == 0
+    }
+
+    /// `local_host:local_port` as a `SocketAddr`. Use the resulting value's
+    /// `Display` for binding/listening — that path brackets IPv6 literals
+    /// correctly (`[::1]:8080`), unlike the `IpAddr` `Display` we'd get from
+    /// a manual `format!("{}:{}", ip, port)`.
+    pub fn local_socket_addr(&self) -> SocketAddr {
+        SocketAddr::new(self.local_host, self.local_port)
+    }
+
+    /// `remote_host:remote_port` formatted for `TcpStream::connect`,
+    /// `UdpSocket::send_to`, and friends. Brackets bare IPv6 literals
+    /// (`::1` → `[::1]:80`); leaves DNS names and IPv4 literals untouched
+    /// so they still feed into `ToSocketAddrs` resolution unchanged.
+    pub fn remote_addr_string(&self) -> String {
+        if self.remote_host.parse::<Ipv6Addr>().is_ok() {
+            format!("[{}]:{}", self.remote_host, self.remote_port)
+        } else {
+            format!("{}:{}", self.remote_host, self.remote_port)
         }
+    }
+}
+
+/// Split an address string on `:` while treating `[...]` segments as a
+/// single atomic token. Without this, IPv6 literals (which contain `:`)
+/// can't survive the parser's address split. A token's surrounding
+/// brackets are *kept* in the returned slice so the caller can recognize
+/// IPv6 literals later via [`unbracket`]; everything else passes through
+/// unchanged.
+fn split_addr_tokens(s: &str) -> Result<Vec<&str>> {
+    let bytes = s.as_bytes();
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'[' {
+            let close_rel = bytes[i + 1..]
+                .iter()
+                .position(|&b| b == b']')
+                .ok_or_else(|| anyhow!("Invalid format: unterminated '['"))?;
+            let close = i + 1 + close_rel;
+            tokens.push(&s[i..=close]);
+            i = close + 1;
+            if i < bytes.len() {
+                if bytes[i] != b':' {
+                    return Err(anyhow!("Invalid format: expected ':' after ']'"));
+                }
+                i += 1;
+                if i == bytes.len() {
+                    return Err(anyhow!("Invalid format: trailing ':' after ']'"));
+                }
+            }
+        } else {
+            let next = bytes[i..]
+                .iter()
+                .position(|&b| b == b':')
+                .map(|p| i + p)
+                .unwrap_or(bytes.len());
+            tokens.push(&s[i..next]);
+            i = next;
+            if i < bytes.len() {
+                i += 1;
+                if i == bytes.len() {
+                    return Err(anyhow!("Invalid format: trailing ':'"));
+                }
+            }
+        }
+    }
+    Ok(tokens)
+}
+
+/// Strip the outer `[...]` from a token if present. Used to turn a
+/// bracketed IPv6 literal back into something `IpAddr::from_str` accepts.
+fn unbracket(s: &str) -> &str {
+    if s.len() >= 2 && s.starts_with('[') && s.ends_with(']') {
+        &s[1..s.len() - 1]
+    } else {
+        s
     }
 }
 
@@ -81,17 +156,21 @@ impl FromStr for RemoteRequest {
             }
         }
 
-        let address_parts: Vec<&str> = inner_remote_str.split(':').collect();
+        // Bracket-aware split so IPv6 literals (which contain `:`) survive
+        // intact: `[::1]:80` tokenizes to `["[::1]", "80"]`, not `["[", "",
+        // "1]", "80"]`. Tokens that came from `[...]` keep their brackets
+        // here and get stripped at parse time via `unbracket`.
+        let address_parts: Vec<&str> = split_addr_tokens(inner_remote_str)?;
 
         // Parse address parts and apply defaults based on the format
         let (local_host, local_port, remote_host, remote_port) = match address_parts.len() {
             1 => match address_parts[0] {
-                "socks" => (
+                SOCKS_SENTINEL_HOST => (
                     "127.0.0.1"
                         .parse::<IpAddr>()
                         .map_err(|_| anyhow!("Invalid IP address"))?,
                     1080,
-                    String::from("socks"),
+                    SOCKS_SENTINEL_HOST.to_string(),
                     0,
                 ),
                 _ => {
@@ -109,7 +188,7 @@ impl FromStr for RemoteRequest {
                 }
             },
             2 => match address_parts[1] {
-                "socks" => {
+                SOCKS_SENTINEL_HOST => {
                     let local_port = address_parts[0]
                         .parse::<u16>()
                         .map_err(|_| anyhow!("Invalid remote port"))?;
@@ -118,12 +197,12 @@ impl FromStr for RemoteRequest {
                             .parse::<IpAddr>()
                             .map_err(|_| anyhow!("Invalid IP address"))?,
                         local_port,
-                        String::from("socks"),
+                        SOCKS_SENTINEL_HOST.to_string(),
                         0,
                     )
                 }
                 _ => {
-                    let remote_host = address_parts[0].to_string();
+                    let remote_host = unbracket(address_parts[0]).to_string();
                     let remote_port = address_parts[1]
                         .parse::<u16>()
                         .map_err(|_| anyhow!("Invalid remote port"))?;
@@ -138,20 +217,20 @@ impl FromStr for RemoteRequest {
                 }
             },
             3 => match address_parts[2] {
-                "socks" => {
-                    let local_host = address_parts[0]
+                SOCKS_SENTINEL_HOST => {
+                    let local_host = unbracket(address_parts[0])
                         .parse::<IpAddr>()
                         .map_err(|_| anyhow!("Invalid local host"))?;
                     let local_port = address_parts[1]
                         .parse::<u16>()
                         .map_err(|_| anyhow!("Invalid local port"))?;
-                    (local_host, local_port, String::from("socks"), 0)
+                    (local_host, local_port, SOCKS_SENTINEL_HOST.to_string(), 0)
                 }
                 _ => {
                     let local_port = address_parts[0]
                         .parse::<u16>()
                         .map_err(|_| anyhow!("Invalid local port"))?;
-                    let remote_host = address_parts[1].to_string();
+                    let remote_host = unbracket(address_parts[1]).to_string();
                     let remote_port = address_parts[2]
                         .parse::<u16>()
                         .map_err(|_| anyhow!("Invalid remote port"))?;
@@ -166,13 +245,13 @@ impl FromStr for RemoteRequest {
                 }
             },
             4 => {
-                let local_host = address_parts[0]
+                let local_host = unbracket(address_parts[0])
                     .parse::<IpAddr>()
                     .map_err(|_| anyhow!("Invalid local host"))?;
                 let local_port = address_parts[1]
                     .parse::<u16>()
                     .map_err(|_| anyhow!("Invalid local port"))?;
-                let remote_host = address_parts[2].to_string();
+                let remote_host = unbracket(address_parts[2]).to_string();
                 let remote_port = address_parts[3]
                     .parse::<u16>()
                     .map_err(|_| anyhow!("Invalid remote port"))?;
@@ -210,13 +289,15 @@ impl fmt::Display for RemoteRequest {
         if self.reversed {
             write!(f, "R:")?;
         }
-        if self.remote_host == "socks" {
+        if self.remote_host == SOCKS_SENTINEL_HOST {
             write!(f, "{}=>socks", self.local_port)
         } else {
             write!(
                 f,
-                "{}=>{}:{}/{}",
-                self.local_port, self.remote_host, self.remote_port, self.protocol
+                "{}=>{}/{}",
+                self.local_port,
+                self.remote_addr_string(),
+                self.protocol
             )
         }
     }
@@ -231,3 +312,235 @@ pub enum RemoteResponse {
 }
 
 impl SerdeHelper for RemoteResponse {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(s: &str) -> RemoteRequest {
+        RemoteRequest::from_str(s).unwrap_or_else(|e| panic!("expected `{s}` to parse: {e}"))
+    }
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn forward_just_remote_port() {
+        let r = parse("1337");
+        assert_eq!(r.local_host, ip("0.0.0.0"));
+        assert_eq!(r.local_port, 1337);
+        assert_eq!(r.remote_host, "0.0.0.0");
+        assert_eq!(r.remote_port, 1337);
+        assert!(!r.reversed);
+        assert_eq!(r.protocol, Protocol::Tcp);
+    }
+
+    #[test]
+    fn forward_remote_host_and_port() {
+        let r = parse("example.com:1337");
+        assert_eq!(r.local_host, ip("0.0.0.0"));
+        assert_eq!(r.local_port, 1337);
+        assert_eq!(r.remote_host, "example.com");
+        assert_eq!(r.remote_port, 1337);
+        assert!(!r.reversed);
+    }
+
+    #[test]
+    fn forward_local_port_remote_host_port() {
+        let r = parse("1337:google.com:80");
+        assert_eq!(r.local_host, ip("0.0.0.0"));
+        assert_eq!(r.local_port, 1337);
+        assert_eq!(r.remote_host, "google.com");
+        assert_eq!(r.remote_port, 80);
+    }
+
+    #[test]
+    fn forward_full_quadruple() {
+        let r = parse("192.168.1.14:5000:google.com:80");
+        assert_eq!(r.local_host, ip("192.168.1.14"));
+        assert_eq!(r.local_port, 5000);
+        assert_eq!(r.remote_host, "google.com");
+        assert_eq!(r.remote_port, 80);
+    }
+
+    #[test]
+    fn forward_udp_protocol_suffix() {
+        let r = parse("1.1.1.1:53/udp");
+        assert_eq!(r.remote_host, "1.1.1.1");
+        assert_eq!(r.remote_port, 53);
+        assert_eq!(r.protocol, Protocol::Udp);
+    }
+
+    #[test]
+    fn socks_default_local() {
+        let r = parse("socks");
+        assert_eq!(r.local_host, ip("127.0.0.1"));
+        assert_eq!(r.local_port, 1080);
+        assert_eq!(r.remote_host, "socks");
+        assert_eq!(r.remote_port, 0);
+        assert!(!r.reversed);
+    }
+
+    #[test]
+    fn socks_custom_local_port() {
+        let r = parse("5000:socks");
+        assert_eq!(r.local_host, ip("127.0.0.1"));
+        assert_eq!(r.local_port, 5000);
+        assert_eq!(r.remote_host, "socks");
+    }
+
+    #[test]
+    fn reverse_prefix_with_port() {
+        let r = parse("R:2222:localhost:22");
+        assert!(r.reversed);
+        assert_eq!(r.local_port, 2222);
+        assert_eq!(r.remote_host, "localhost");
+        assert_eq!(r.remote_port, 22);
+    }
+
+    #[test]
+    fn reverse_socks_default_local() {
+        let r = parse("R:socks");
+        assert!(r.reversed);
+        assert_eq!(r.local_host, ip("127.0.0.1"));
+        assert_eq!(r.local_port, 1080);
+        assert_eq!(r.remote_host, "socks");
+    }
+
+    #[test]
+    fn reverse_socks_custom_local_port() {
+        let r = parse("R:5000:socks");
+        assert!(r.reversed);
+        assert_eq!(r.local_port, 5000);
+        assert_eq!(r.remote_host, "socks");
+    }
+
+    #[test]
+    fn rejects_unknown_protocol() {
+        let err = RemoteRequest::from_str("1.1.1.1:53/sctp").unwrap_err();
+        assert!(
+            err.to_string().contains("Invalid protocol"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_local_ip() {
+        let err = RemoteRequest::from_str("not-an-ip:1:host:80").unwrap_err();
+        assert!(
+            err.to_string().contains("Invalid local host"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_port() {
+        let err = RemoteRequest::from_str("99999").unwrap_err();
+        assert!(
+            err.to_string().contains("Invalid remote port"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_too_many_address_parts() {
+        let err = RemoteRequest::from_str("a:b:c:d:e").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Unexpected number of address parts"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn ipv6_remote_host_port() {
+        let r = parse("[::1]:80");
+        assert_eq!(r.local_host, ip("0.0.0.0"));
+        assert_eq!(r.local_port, 80);
+        assert_eq!(r.remote_host, "::1");
+        assert_eq!(r.remote_port, 80);
+    }
+
+    #[test]
+    fn ipv6_local_port_remote_host_port() {
+        let r = parse("8080:[2001:db8::1]:443");
+        assert_eq!(r.local_host, ip("0.0.0.0"));
+        assert_eq!(r.local_port, 8080);
+        assert_eq!(r.remote_host, "2001:db8::1");
+        assert_eq!(r.remote_port, 443);
+    }
+
+    #[test]
+    fn ipv6_full_quadruple() {
+        let r = parse("[::1]:5000:[2001:db8::1]:80/udp");
+        assert_eq!(r.local_host, ip("::1"));
+        assert_eq!(r.local_port, 5000);
+        assert_eq!(r.remote_host, "2001:db8::1");
+        assert_eq!(r.remote_port, 80);
+        assert_eq!(r.protocol, Protocol::Udp);
+    }
+
+    #[test]
+    fn ipv6_local_only_with_socks() {
+        let r = parse("[::1]:1080:socks");
+        assert_eq!(r.local_host, ip("::1"));
+        assert_eq!(r.local_port, 1080);
+        assert!(r.is_socks());
+    }
+
+    #[test]
+    fn ipv6_reverse() {
+        let r = parse("R:[::1]:5000:[2001:db8::1]:80");
+        assert!(r.reversed);
+        assert_eq!(r.local_host, ip("::1"));
+        assert_eq!(r.remote_host, "2001:db8::1");
+    }
+
+    #[test]
+    fn rejects_unterminated_bracket() {
+        let err = RemoteRequest::from_str("[::1:80").unwrap_err();
+        assert!(
+            err.to_string().contains("unterminated"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_missing_colon_after_bracket() {
+        // `[::1]80` (no `:` between `]` and the port) is an obvious
+        // user typo; reject it explicitly rather than silently producing
+        // a one-token parse that fails later with a misleading error.
+        let err = RemoteRequest::from_str("[::1]80").unwrap_err();
+        assert!(
+            err.to_string().contains("expected ':'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn unbracketed_ipv6_still_rejected() {
+        // Bare colon-rich tokens have always been ambiguous (could be
+        // IPv6 or could be `host:port:host:port…`). We require brackets
+        // for IPv6 — same rule HTTP, ssh, and curl all use.
+        assert!(RemoteRequest::from_str("fe80::1:53").is_err());
+    }
+
+    #[test]
+    fn remote_addr_string_brackets_ipv6() {
+        let r = parse("[2001:db8::1]:443");
+        assert_eq!(r.remote_addr_string(), "[2001:db8::1]:443");
+    }
+
+    #[test]
+    fn remote_addr_string_passes_dns_through() {
+        let r = parse("example.com:80");
+        assert_eq!(r.remote_addr_string(), "example.com:80");
+    }
+
+    #[test]
+    fn local_socket_addr_handles_ipv6() {
+        let r = parse("[::1]:8080:example.com:80");
+        assert_eq!(r.local_socket_addr().to_string(), "[::1]:8080");
+    }
+}

--- a/src/common/socks.rs
+++ b/src/common/socks.rs
@@ -14,9 +14,9 @@ use super::tunnel::client_send_remote_request;
 use anyhow::{anyhow, Result};
 
 pub async fn tunnel_socks_client(quic_connection: Connection, remote: RemoteRequest) -> Result<()> {
-    let local_addr = format!("{}:{}", remote.local_host, remote.local_port);
-    let listener = TcpListener::bind(&local_addr).await?;
-    info!("SOCKS5 listening on {}", &local_addr);
+    let local_addr = remote.local_socket_addr();
+    let listener = TcpListener::bind(local_addr).await?;
+    info!("SOCKS5 listening on {}", local_addr);
 
     let conn_counter = AtomicUsize::new(0);
 
@@ -109,14 +109,14 @@ async fn socks_handshake(
             conn.read_exact(&mut port).await?;
             let port = u16::from_be_bytes(port);
             let remote_address = Ipv4Addr::from(addr).to_string();
-            RemoteRequest::new(
-                original_remote.local_host,
-                original_remote.local_port,
-                remote_address,
-                port,
-                original_remote.reversed,
-                remote::Protocol::Tcp,
-            )
+            RemoteRequest {
+                local_host: original_remote.local_host,
+                local_port: original_remote.local_port,
+                remote_host: remote_address,
+                remote_port: port,
+                reversed: original_remote.reversed,
+                protocol: remote::Protocol::Tcp,
+            }
         }
         0x03 => {
             // Domain name
@@ -128,14 +128,14 @@ async fn socks_handshake(
             conn.read_exact(&mut port).await?;
             let port = u16::from_be_bytes(port);
             let domain = String::from_utf8_lossy(&domain).into_owned();
-            RemoteRequest::new(
-                original_remote.local_host,
-                original_remote.local_port,
-                domain,
-                port,
-                original_remote.reversed,
-                remote::Protocol::Tcp,
-            )
+            RemoteRequest {
+                local_host: original_remote.local_host,
+                local_port: original_remote.local_port,
+                remote_host: domain,
+                remote_port: port,
+                reversed: original_remote.reversed,
+                protocol: remote::Protocol::Tcp,
+            }
         }
         _ => {
             conn.write_all(&[0x05, 0x08]).await?;

--- a/src/common/tcp.rs
+++ b/src/common/tcp.rs
@@ -67,8 +67,11 @@ pub async fn tunnel_tcp_stream(
 }
 
 pub async fn tunnel_tcp_client(quic_connection: Connection, remote: RemoteRequest) -> Result<()> {
-    let local_addr = format!("{}:{}", remote.local_host, remote.local_port);
-    let listener = TcpListener::bind(&local_addr).await?;
+    // Use SocketAddr's Display so IPv6 literals come out bracketed
+    // (`[::1]:8080`) — a manual `format!("{ip}:{port}")` on an IPv6
+    // `IpAddr` produces `::1:8080`, which `TcpListener::bind` rejects.
+    let local_addr = remote.local_socket_addr();
+    let listener = TcpListener::bind(local_addr).await?;
     info!("listening on {}", local_addr);
 
     let conn_counter = AtomicUsize::new(0);
@@ -100,7 +103,7 @@ pub async fn tunnel_tcp_server(
     send_channel: SendStream,
     request: RemoteRequest,
 ) -> Result<()> {
-    let remote_addr = format!("{}:{}", request.remote_host, request.remote_port);
+    let remote_addr = request.remote_addr_string();
     debug!("connecting to {}", remote_addr);
     let tcp_stream = TcpStream::connect(&remote_addr).await?;
     debug!("connected to {}", remote_addr);

--- a/src/common/udp.rs
+++ b/src/common/udp.rs
@@ -66,38 +66,16 @@ async fn read_datagram<'a>(recv: &mut RecvStream, buf: &'a mut [u8]) -> Result<&
 pub async fn tunnel_udp_stream(
     udp_socket: Arc<UdpSocket>,
     udp_address: SocketAddr,
-    mut send_channel: SendStream,
-    mut recv_channel: RecvStream,
+    send_channel: SendStream,
+    recv_channel: RecvStream,
 ) -> Result<()> {
-    let socket_for_recv = udp_socket.clone();
-    let local_to_quic = async move {
-        let mut buf = vec![0u8; MAX_DATAGRAM];
-        loop {
-            let (len, received_addr) = socket_for_recv.recv_from(&mut buf).await?;
-            if received_addr != udp_address {
-                debug!(peer = %received_addr, expected = %udp_address, "dropping datagram from unexpected source");
-                continue;
-            }
-            write_datagram(&mut send_channel, &buf[..len]).await?;
-        }
-        #[allow(unreachable_code)]
-        Ok::<(), anyhow::Error>(())
-    };
-
-    let quic_to_local = async move {
-        let mut buf = vec![0u8; MAX_DATAGRAM];
-        loop {
-            let payload = read_datagram(&mut recv_channel, &mut buf).await?;
-            udp_socket.send_to(payload, &udp_address).await?;
-        }
-        #[allow(unreachable_code)]
-        Ok::<(), anyhow::Error>(())
-    };
-
     // tokio::join! (not try_join!) so a write error in one direction does not
     // cancel an in-flight read in the other (#20 §3). UDP is unreliable so we
     // just log and let the connection close.
-    let (l2q, q2l) = tokio::join!(local_to_quic, quic_to_local);
+    let (l2q, q2l) = tokio::join!(
+        pump_socket_to_stream(udp_socket.clone(), udp_address, send_channel),
+        pump_stream_to_socket(udp_socket, udp_address, recv_channel),
+    );
     if let Err(e) = l2q {
         debug!("local→quic error: {}", e);
     }
@@ -107,12 +85,44 @@ pub async fn tunnel_udp_stream(
     Ok(())
 }
 
+/// Read datagrams arriving on `udp_socket` from `udp_address` and forward
+/// them onto the QUIC `send` stream. Returns only on error — the trailing
+/// `loop {}` has type `!`, which coerces to `Result<()>` without a stub
+/// return statement.
+async fn pump_socket_to_stream(
+    udp_socket: Arc<UdpSocket>,
+    udp_address: SocketAddr,
+    mut send: SendStream,
+) -> Result<()> {
+    let mut buf = vec![0u8; MAX_DATAGRAM];
+    loop {
+        let (len, received_addr) = udp_socket.recv_from(&mut buf).await?;
+        if received_addr != udp_address {
+            debug!(peer = %received_addr, expected = %udp_address, "dropping datagram from unexpected source");
+            continue;
+        }
+        write_datagram(&mut send, &buf[..len]).await?;
+    }
+}
+
+async fn pump_stream_to_socket(
+    udp_socket: Arc<UdpSocket>,
+    udp_address: SocketAddr,
+    mut recv: RecvStream,
+) -> Result<()> {
+    let mut buf = vec![0u8; MAX_DATAGRAM];
+    loop {
+        let payload = read_datagram(&mut recv, &mut buf).await?;
+        udp_socket.send_to(payload, &udp_address).await?;
+    }
+}
+
 /// Client-side forward UDP: accept datagrams from any number of local
 /// senders and multiplex each source onto its own QUIC bi-stream. Sessions
 /// are torn down after `SESSION_IDLE_TIMEOUT` of inactivity.
 pub async fn tunnel_udp_client(quic_connection: Connection, remote: RemoteRequest) -> Result<()> {
-    let listen_addr = format!("{}:{}", remote.local_host, remote.local_port);
-    let udp_socket = Arc::new(UdpSocket::bind(&listen_addr).await?);
+    let listen_addr = remote.local_socket_addr();
+    let udp_socket = Arc::new(UdpSocket::bind(listen_addr).await?);
 
     info!("listening on {}", listen_addr);
 
@@ -192,26 +202,24 @@ async fn run_udp_session(
         loop {
             match tokio::time::timeout(SESSION_IDLE_TIMEOUT, rx.recv()).await {
                 Ok(Some(payload)) => write_datagram(&mut send_channel, &payload).await?,
-                Ok(None) => return Ok(()), // sender side closed
+                Ok(None) => return Ok::<(), anyhow::Error>(()), // sender side closed
                 Err(_) => {
                     debug!(peer = %source, "UDP session idle timeout");
                     return Ok(());
                 }
             }
         }
-        #[allow(unreachable_code)]
-        Ok::<(), anyhow::Error>(())
     };
 
     // Forward replies from the QUIC stream back to the original local sender.
+    // The inner `loop` only exits via `?`, so the function body has type `!`
+    // and no trailing `Ok` is needed.
     let quic_to_local = async {
         let mut buf = vec![0u8; MAX_DATAGRAM];
         loop {
             let payload = read_datagram(&mut recv_channel, &mut buf).await?;
             udp_socket.send_to(payload, &source).await?;
         }
-        #[allow(unreachable_code)]
-        Ok::<(), anyhow::Error>(())
     };
 
     // Either branch finishing tears the session down — UDP has no "half-close"
@@ -227,11 +235,19 @@ pub async fn tunnel_udp_server(
     send_channel: SendStream,
     request: RemoteRequest,
 ) -> Result<()> {
-    let remote_addr: SocketAddr = format!("{}:{}", request.remote_host, request.remote_port)
+    let remote_addr: SocketAddr = request
+        .remote_addr_string()
         .parse()
         .context("Failed to parse remote address")?;
 
-    let udp_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
+    // Bind in the same address family as the upstream target. Without this
+    // an IPv6 remote ends up trying to send from a v4-only socket and
+    // returns `AddressFamilyNotSupported`.
+    let bind_addr = match remote_addr {
+        SocketAddr::V4(_) => "0.0.0.0:0",
+        SocketAddr::V6(_) => "[::]:0",
+    };
+    let udp_socket = Arc::new(UdpSocket::bind(bind_addr).await?);
 
     debug!("connecting to {}", remote_addr);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,22 +123,32 @@ impl Default for ReconnectConfig {
     }
 }
 
+/// Build a multi-thread tokio runtime and run the server to completion.
+///
+/// This is the synchronous convenience entry point used by `main`. Embedders
+/// inside an existing async context should call [`server::run_async`]
+/// directly so they don't end up nesting runtimes (which would either panic
+/// in debug builds or silently deadlock in release).
 pub fn run_server(config: ServerConfig) {
     info!("running server");
-    match server::run(config) {
-        Ok(_) => {}
-        Err(e) => {
-            error!("an error occurred: {}", e)
-        }
+    let result = build_runtime().and_then(|rt| rt.block_on(server::run_async(config)));
+    if let Err(e) = result {
+        error!("an error occurred: {}", e);
     }
 }
 
+/// Build a multi-thread tokio runtime and run the client to completion.
+///
+/// See [`run_server`] for the rationale on why embedders should prefer
+/// [`client::run_async`].
 pub fn run_client(config: ClientConfig) {
     info!("running client");
-    match client::run(config) {
-        Ok(_) => {}
-        Err(e) => {
-            error!("an error occured: {}", e)
-        }
+    let result = build_runtime().and_then(|rt| rt.block_on(client::run_async(config)));
+    if let Err(e) = result {
+        error!("an error occurred: {}", e);
     }
+}
+
+fn build_runtime() -> anyhow::Result<tokio::runtime::Runtime> {
+    tokio::runtime::Runtime::new().map_err(Into::into)
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -8,7 +8,7 @@ use tokio::task::JoinSet;
 use tracing::{debug, error, info, info_span, Instrument};
 
 use crate::common::quic::create_server_endpoint;
-use crate::common::remote::{Protocol, RemoteRequest};
+use crate::common::remote::Protocol;
 use crate::common::socks::tunnel_socks_client;
 use crate::common::tcp::{tunnel_tcp_client, tunnel_tcp_server};
 use crate::common::tunnel::server_receive_remote_request;
@@ -19,10 +19,6 @@ use crate::ServerConfig;
 /// values purely so the wire dumps from the two tools look similar; the QUIC
 /// layer treats the numeric value as opaque.
 const CLOSE_CODE_SERVER_SHUTDOWN: u32 = 0;
-
-pub fn run(config: ServerConfig) -> Result<()> {
-    tokio::runtime::Runtime::new()?.block_on(run_async(config))
-}
 
 pub async fn run_async(config: ServerConfig) -> Result<()> {
     let endpoint =
@@ -163,66 +159,20 @@ async fn handle_remote_stream(
     async {
         info!("tunnel established");
 
-        match request {
-            // reverse socks
-            RemoteRequest {
-                local_host: _,
-                local_port: _,
-                remote_host: ref remote_host_ref,
-                remote_port: 0,
-                reversed: true,
-                protocol: Protocol::Tcp,
-            } if remote_host_ref == "socks" => {
-                tunnel_socks_client(quic_connection, request).await?;
-            }
+        // Reverse SOCKS is the only special case — it ignores the
+        // (remote_host, remote_port) pair on the request because the actual
+        // target is supplied later, per-connection, by the SOCKS handshake.
+        // Everything else dispatches purely on (reversed, protocol).
+        if request.is_socks() && request.reversed {
+            tunnel_socks_client(quic_connection, request).await?;
+            return Ok(());
+        }
 
-            // simple forward TCP
-            RemoteRequest {
-                local_host: _,
-                local_port: _,
-                remote_host: _,
-                remote_port: _,
-                reversed: false,
-                protocol: Protocol::Tcp,
-            } => {
-                tunnel_tcp_server(recv, send, request).await?;
-            }
-
-            // simple reverse TCP
-            RemoteRequest {
-                local_host: _,
-                local_port: _,
-                remote_host: _,
-                remote_port: _,
-                reversed: true,
-                protocol: Protocol::Tcp,
-            } => {
-                tunnel_tcp_client(quic_connection, request).await?;
-            }
-
-            // simple forward UDP
-            RemoteRequest {
-                local_host: _,
-                local_port: _,
-                remote_host: _,
-                remote_port: _,
-                reversed: false,
-                protocol: Protocol::Udp,
-            } => {
-                tunnel_udp_server(recv, send, request).await?;
-            }
-
-            // simple reverse UDP
-            RemoteRequest {
-                local_host: _,
-                local_port: _,
-                remote_host: _,
-                remote_port: _,
-                reversed: true,
-                protocol: Protocol::Udp,
-            } => {
-                tunnel_udp_client(quic_connection, request).await?;
-            }
+        match (request.reversed, request.protocol) {
+            (false, Protocol::Tcp) => tunnel_tcp_server(recv, send, request).await?,
+            (true, Protocol::Tcp) => tunnel_tcp_client(quic_connection, request).await?,
+            (false, Protocol::Udp) => tunnel_udp_server(recv, send, request).await?,
+            (true, Protocol::Udp) => tunnel_udp_client(quic_connection, request).await?,
         }
 
         Ok(())

--- a/tests/ipv6.rs
+++ b/tests/ipv6.rs
@@ -1,0 +1,130 @@
+//! End-to-end IPv6 sanity tests for the address parser + connect path.
+//!
+//! The tunneling tests in `tunnels.rs` exercise the IPv4 happy paths; this
+//! file specifically validates that:
+//!
+//! 1. `[::1]:port:[::1]:port` round-trips through `RemoteRequest::from_str`
+//!    and the per-protocol handlers without losing the IPv6 family.
+//! 2. The `local_socket_addr` / `remote_addr_string` helpers produce
+//!    listen/connect strings that bind on `::1` and reach an IPv6-only
+//!    upstream — i.e. a future regression that drops the brackets and
+//!    silently falls back to IPv4 would fail this test.
+
+mod common;
+
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use std::str::FromStr;
+use std::time::Duration;
+
+use rusnel::common::remote::RemoteRequest;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream, UdpSocket};
+use tokio::time::timeout;
+
+use common::{get_available_port, start_tunnel, TEST_TIMEOUT};
+
+/// Reserve an ephemeral port on `[::1]` (IPv6 loopback). The cross-family
+/// helper in `common::get_available_port` only probes IPv4; we want the
+/// kernel to give us a port that's actually free on the v6 loopback for
+/// these IPv6-specific tests.
+fn get_available_v6_port() -> u16 {
+    let listener =
+        std::net::TcpListener::bind(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0)).unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+fn get_available_v6_udp_port() -> u16 {
+    let socket =
+        std::net::UdpSocket::bind(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0)).unwrap();
+    socket.local_addr().unwrap().port()
+}
+
+#[tokio::test]
+async fn tcp_forward_over_ipv6() {
+    let server_port = get_available_port();
+    let local_port = get_available_v6_port();
+    let upstream_port = get_available_v6_port();
+
+    // Spin up an IPv6 echo server on `[::1]:upstream_port`.
+    let upstream = TcpListener::bind(SocketAddr::new(
+        IpAddr::V6(Ipv6Addr::LOCALHOST),
+        upstream_port,
+    ))
+    .await
+    .unwrap();
+    let upstream_handle = tokio::spawn(async move {
+        let (mut conn, _) = upstream.accept().await.unwrap();
+        let mut buf = [0u8; 32];
+        let n = conn.read(&mut buf).await.unwrap();
+        conn.write_all(&buf[..n]).await.unwrap();
+    });
+
+    let remote_str = format!("[::1]:{local_port}:[::1]:{upstream_port}");
+    let remote = RemoteRequest::from_str(&remote_str).unwrap();
+    assert_eq!(remote.local_host, IpAddr::V6(Ipv6Addr::LOCALHOST));
+    assert_eq!(remote.remote_host, "::1");
+
+    let _env = start_tunnel(server_port, false, vec![remote]).await;
+
+    let mut stream = timeout(
+        TEST_TIMEOUT,
+        TcpStream::connect(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), local_port)),
+    )
+    .await
+    .expect("connect to v6 tunnel listener timed out")
+    .expect("connect failed");
+
+    stream.write_all(b"hello-v6").await.unwrap();
+    let mut buf = [0u8; 8];
+    timeout(TEST_TIMEOUT, stream.read_exact(&mut buf))
+        .await
+        .expect("read echo timed out")
+        .expect("read echo failed");
+    assert_eq!(&buf, b"hello-v6");
+
+    upstream_handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn udp_forward_over_ipv6() {
+    let server_port = get_available_port();
+    let local_port = get_available_v6_udp_port();
+    let upstream_port = get_available_v6_udp_port();
+
+    // IPv6 echo server.
+    let upstream = UdpSocket::bind(SocketAddr::new(
+        IpAddr::V6(Ipv6Addr::LOCALHOST),
+        upstream_port,
+    ))
+    .await
+    .unwrap();
+    let upstream_handle = tokio::spawn(async move {
+        let mut buf = [0u8; 64];
+        let (n, src) = upstream.recv_from(&mut buf).await.unwrap();
+        upstream.send_to(&buf[..n], src).await.unwrap();
+    });
+
+    let remote =
+        RemoteRequest::from_str(&format!("[::1]:{local_port}:[::1]:{upstream_port}/udp")).unwrap();
+    let _env = start_tunnel(server_port, false, vec![remote]).await;
+
+    let client = UdpSocket::bind(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0))
+        .await
+        .unwrap();
+    client
+        .send_to(
+            b"hello-v6-udp",
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), local_port),
+        )
+        .await
+        .unwrap();
+
+    let mut buf = [0u8; 64];
+    let (n, _) = timeout(Duration::from_secs(5), client.recv_from(&mut buf))
+        .await
+        .expect("udp echo timed out")
+        .expect("udp recv failed");
+    assert_eq!(&buf[..n], b"hello-v6-udp");
+
+    upstream_handle.await.unwrap();
+}


### PR DESCRIPTION
Resolves the bulk of review issues #17, #19, #21, #22 (all closed). The remaining follow-ups are tracked in #33.

## Summary

- **QUIC hardening** — `max_idle_timeout = 30s` and per-connection stream caps (`max_concurrent_bidi_streams = 1024`, `max_concurrent_uni_streams = 0`) close the half-open / unlimited-stream DoS exposure.
- **IPv6 support, end to end** — bracketed literals (`[::1]:80`, `[::1]:5000:[2001:db8::1]:80/udp`, `R:[::1]:...`, etc.) parse, listen, and connect correctly across TCP / UDP / SOCKS5. UDP server binds in the matching address family.
- **Dispatch flattening** — the six-field `RemoteRequest { _, _, _, _, reversed, protocol }` match arms with all-`_` placeholders are gone from `server/mod.rs` and `client/mod.rs`; ~80 lines deleted, dispatch is now `match (reversed, protocol)` and exhaustive without placeholders.
- **Runtime ownership cleanup** — drop `server::run` / `client::run` sync wrappers; runtime is now built once in `lib::run_server` / `lib::run_client`. `*::run_async` are the canonical entry points (which the integration suite already used).
- **Code quality** — 25 new `RemoteRequest::from_str` unit tests, `Protocol` is `Copy`, four `#[allow(unreachable_code)]` markers eliminated, `"occured"` typo fixed, unused `RemoteRequest::new` removed.

Bumps version to **0.3.8**. Wire format is unchanged.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all` — **77 tests pass** (32 lib + 3 bin + 42 integration). Highlights:
  - `tests/ipv6.rs` (new) — IPv6 TCP and UDP echo through a tunneled `[::1]:port:[::1]:port` remote.
  - `tests/auth.rs` — fingerprint pin, mTLS, mTLS-rejects-no-cert, mTLS-rejects-wrong-CA, CA-only.
  - `tests/reconnect.rs` — client reconnect before server up / after server restart.
  - `tests/disconnect_cleanup.rs` — server releases reverse listener on client disconnect.

## Closed issues

- Closes #17 (security): cert verification + mTLS + Ctrl-C + idle timeout + stream caps.
- Closes #19 (architecture): runtime ownership, MessagePack control plane, IPv6, dispatch flattening, SOCKS sentinel localized.
- Closes #21 (performance): MessagePack, JoinSet, persisted cert, IPv4 bind family, transport tuning.
- Closes #22 (code quality): typos, dead code, ALPN, CI tests, parser tests, `Protocol: Copy`, `clap` plumbing.

Remaining follow-ups (full `RemoteKind` enum refactor, global connection cap, lint policy, UDP per-loop alloc, parser combinator rewrite) are tracked in #33.

Made with [Cursor](https://cursor.com)