### PR TITLE
Add --allow-socks server flag and --proxy socks5 client support (v0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to this project are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-05-03
+
+Two new server/client features from the README roadmap:
+
+### Added
+
+- **`--allow-socks` server flag**. Default-deny gate for reverse-SOCKS5
+  remotes (`R:socks` / `R:port:socks`). Without the flag the server now
+  rejects reverse-SOCKS requests at the control-plane handshake instead
+  of silently spinning up a local SOCKS listener that exposes the
+  server's network to the connecting client. Mirrors the existing
+  `--allow-reverse` semantics. Forward SOCKS (`socks`) decomposes into
+  per-target dynamic TCP/UDP requests on the wire and is *not* gated by
+  this flag — see the README's "Security & access control" roadmap for
+  the planned full ACL story (per-cert allow/deny patterns).
+- **`--proxy` client flag** for routing the QUIC connection through a
+  SOCKS5 proxy via UDP ASSOCIATE (RFC 1928 §4). Accepts
+  `socks5://[user:pass@]host:port` (`socks://` is an alias). HTTP
+  CONNECT is intentionally not supported in this release because it
+  cannot carry UDP — see the "WebSocket fallback transport" roadmap
+  bullet for the path that would unlock HTTP/SOCKS-CONNECT proxies.
+  - New `rusnel::common::proxy` module: `ProxyConfig` parser, SOCKS5
+    UDP ASSOCIATE handshake (no-auth and RFC 1929 user/pass), and a
+    `Socks5UdpSocket` adapter implementing `quinn::AsyncUdpSocket` that
+    wraps every outbound QUIC datagram in the SOCKS5 UDP framing
+    (`RSV/FRAG/ATYP/DST.ADDR/DST.PORT`) and unwraps every inbound one.
+  - `create_client_endpoint_via_proxy` builds a single-use QUIC
+    endpoint with the wrapped socket via
+    `Endpoint::new_with_abstract_socket`. The TCP control connection is
+    held open inside the socket for the lifetime of the relay (RFC
+    1928 §6); reconnects open a fresh association.
+  - The client bypasses Happy Eyeballs and the cross-attempt endpoint
+    pool when proxied (the proxy owns routing; each retry needs a
+    fresh association anyway), and instead re-runs the SOCKS5
+    handshake on every connect / reconnect.
+  - 10 unit tests in `src/common/proxy.rs` (URL parser corner cases,
+    SOCKS5 UDP wrap/unwrap roundtrips, fragment/ATYP rejection paths)
+    plus `tests/proxy.rs` — an integration test that stands up an
+    in-process SOCKS5 UDP relay and asserts a Rusnel client connects
+    through it, completes the QUIC handshake, and round-trips bytes
+    over a tunneled TCP echo.
+
+### Notes for downstream embedders
+
+- `ServerConfig` gains `pub allow_socks: bool`. `false` is safe-by-default
+  (matches the `--allow-reverse` precedent); existing embedders relying
+  on reverse-SOCKS need to set `allow_socks: true`.
+- `ClientConfig` gains `pub proxy: Option<ProxyConfig>`. `None` =
+  direct connect (existing behaviour).
+- `server_receive_remote_request` gains an `allow_socks: bool` parameter
+  alongside the existing `allow_reverse`. Wire format unchanged.
+
 ## [0.5.0] - 2026-05-03
 
 Adds SOCKS5 UDP ASSOCIATE (UDP over SOCKS5) and one data-plane scalability

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "rusnel"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusnel"
 description = "Rusnel is a fast TCP/UDP tunnel, transported over and encrypted using QUIC protocol. Single executable including both client and server"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/guyte149/Rusnel"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Options:
       --host <HOST>          defines Rusnel listening host [default: 0.0.0.0]
   -p, --port <PORT>          defines Rusnel listening port [default: 8080]
       --allow-reverse        Allow clients to specify reverse port forwarding remotes
+      --allow-socks          Allow clients to request reverse SOCKS5 dynamic tunnels
+                             (R:socks). Default-deny; forward `socks` is not gated.
       --insecure             Disable all TLS authentication (testing only)
       --tls-self-signed      Persisted self-signed cert under --tls-state-dir
       --tls-state-dir <DIR>  Directory for persisted self-signed cert/key (default: ~/.rusnel)
@@ -143,6 +145,13 @@ Options:
                                   counter resets on every successful connect.
       --max-retry-interval <S>    Cap on the exponential reconnect backoff
                                   (default 300s; starts at 200 ms and doubles).
+      --proxy <URL>               Route the QUIC connection through an outbound
+                                  SOCKS5 proxy via UDP ASSOCIATE (RFC 1928 §4).
+                                  Form: socks5://[user:pass@]host:port (alias:
+                                  socks://). HTTP CONNECT is intentionally NOT
+                                  supported — it cannot carry UDP/QUIC. The
+                                  proxy must permit UDP ASSOCIATE; many
+                                  corporate / hotel HTTP proxies do not.
   -v, --verbose                   enable verbose logging
       --debug                     enable debug logging
   -h, --help                      Print help
@@ -213,30 +222,28 @@ The benchmark harness also includes a `wan` profile that applies
 the script adds for you). See [`benchmark/`](benchmark/) for tunables.
 
 ## TODO
-- [x] write tests in rust for tcp, udp, reverse and socks
-- [x] improve logging by for each tunnel
-- [x] add server tls certificate verification
-- [x] add mutual tls verification
-- [x] disguise traffic as HTTP/3 to bypass DPI firewalls (ALPN `h3`, default UDP/443, configurable SNI, RFC 9000 QUIC version, optionally CA-signed cert and minimal HTTP/3 facade for active probes)
-- [x] benchmark performance against chisel (see [Performance](#performance) — also benchmark against wstunnel, frp)
 
 ### Reliability & UX
 - [x] client reconnect with exponential backoff (configurable via `--max-retry-count` / `--max-retry-interval`)
-- [ ] add proxy support for client (client connects to server through an HTTP/SOCKS proxy)
+- [x] proxy support for client: `--proxy socks5://[user:pass@]host:port` routes the QUIC connection through a SOCKS5 proxy via UDP ASSOCIATE (RFC 1928 §4). HTTP CONNECT is intentionally not supported in this release because it cannot carry UDP — see the WebSocket-fallback transport item under `Security & access control` for the path that would unlock HTTP/SOCKS-CONNECT proxies.
 - [ ] `RUST_LOG`-style env filter for `tracing-subscriber` (per-module log levels)
 
 ### Protocol features
-- [x] support UDP over SOCKS5 (UDP ASSOCIATE) — both forward (`socks`) and reverse (`R:socks`)
 - [ ] add fake-backend http/3 feature to server (real HTTP/3 facade for active probes that open streams)
 - [ ] skip the 1-RTT control handshake on static forwards (cache the parsed `RemoteRequest` server-side; saves ~1 RTT per accepted TCP connection on WAN)
 - [ ] enable QUIC 0-RTT connection resumption (session-ticket cache; cuts the first request after `rusnel client` startup from ~3 RTT to ~1 RTT)
+- [ ] UDP hole-punching / NAT traversal mode: introduce a `rusnel broker` role that observes each peer's reflexive address (optionally cross-checked against public STUN servers to detect symmetric NAT) and brokers a direct QUIC connection between two NATed peers à la libp2p DCUtR / Tailscale DERP, with relay fallback when punching fails. Lets two devices behind NAT talk without anyone running a publicly-reachable data-plane server.
 
-### Data plane performance
-- [x] swap the UDP session map for a sharded lock-free structure (`dashmap`) so the receive loop doesn't serialize on a global mutex under high pps from many sources
-- [x] 256 KB `BufReader`/`copy_buf` is applied to every tunneled TCP leg, including SOCKS5 CONNECT — all three paths share `tunnel_tcp_stream`
-- [ ] single-copy QUIC→TCP data path via `quinn::RecvStream::read_chunk` (tried in 0.5.0; per-chunk syscall overhead regressed loopback throughput ~40 % vs `BufReader`+`copy_buf` because chunks are small — revisit when quinn exposes a vectored `Bytes`-returning read API)
-- [ ] UDP over QUIC datagrams (RFC 9221) instead of length-prefixed reliable streams: removes per-datagram `Vec` alloc, the per-source map lookup, the stream open, and the length frame
+### Security & access control
+- [ ] server-side remote ACLs: `--allow` / `--deny` flags (and config-file equivalents) accepting wildcarded `RemoteRequest` patterns, e.g. `--allow socks`, `--allow R:2222:localhost:22`, `--deny tcp:*:*:169.254.169.254:*`. Default-deny dangerous targets like cloud instance-metadata endpoints. With mTLS, bind ACLs to the client cert subject / fingerprint so a contractor cert can be scoped to one tunnel.
+- [ ] SSO / OIDC client auth via a `rusnel-issuer` daemon: client runs `rusnel client --sso https://issuer.corp.example`, completes a device-code flow against the org's IdP (Okta/Google/Auth0), and the issuer mints a short-lived (~8h) mTLS client cert with the user's email/groups in the SAN. Rusnel server only needs to trust the issuer's CA — no IdP knowledge in the data path. ACLs from the bullet above match on cert subject/groups.
+
+### Operability
+- [ ] server admin API + CLI + web UI:
+  - typed `ServerState` (DashMap of clients/tunnels with bytes-in/out counters) populated from the existing per-connection / per-tunnel handlers.
+  - HTTP admin API on a unix socket (filesystem-perm gated) or TCP+mTLS: `GET /clients`, `GET /clients/:id/tunnels`, `GET /tunnels`, `DELETE /clients/:id` (kick), `GET /metrics` (Prometheus).
+  - `rusnel ctl clients|tunnels|kick` subcommand consuming that API.
+  - tiny embedded web UI (single `include_str!`'d HTML file, no JS framework) with a client/tunnel dashboard and bandwidth sparklines off `/metrics`.
 
 ### Testing & CI
-- [ ] integration test that asserts `--congestion bbr` actually engages BBR (would catch a future quinn API change)
 - [ ] run `./benchmark/run.sh` on a self-hosted runner per release tag and commit the result PNGs back, so perf regressions surface in PRs

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -9,7 +9,9 @@ use tokio::sync::broadcast;
 use tokio::{signal, task};
 use tracing::{debug, error, info, info_span, warn, Instrument};
 
-use crate::common::quic::{client_server_name, create_client_endpoint};
+use crate::common::quic::{
+    client_server_name, create_client_endpoint, create_client_endpoint_via_proxy,
+};
 use crate::common::remote::{Direction, RemoteKind, RemoteRequest};
 use crate::common::socks::tunnel_socks_client;
 use crate::common::tcp::{tunnel_tcp_client, tunnel_tcp_server};
@@ -18,7 +20,17 @@ use crate::common::udp::{tunnel_udp_client, tunnel_udp_server};
 use crate::{ClientConfig, ReconnectConfig};
 
 pub async fn run_async(config: ClientConfig) -> Result<()> {
-    let mut endpoints = EndpointPool::new(&config)?;
+    // Direct connections share QUIC endpoints across reconnects (one per
+    // address family) so we don't pay the bind-syscall cost on every retry.
+    // SOCKS5-proxied connections can't share — each retry requires a fresh
+    // UDP ASSOCIATE — so the pool is built lazily per attempt instead.
+    let mut endpoints = match &config.proxy {
+        None => Some(EndpointPool::new(&config)?),
+        Some(p) => {
+            info!("routing QUIC through proxy: {p}");
+            None
+        }
+    };
     let server_name = client_server_name(&config.tls, &config.server.host);
 
     // Single ^C listener for the lifetime of the process. Sessions subscribe to
@@ -33,9 +45,11 @@ pub async fn run_async(config: ClientConfig) -> Result<()> {
         }
     });
 
-    let result = run_with_reconnect(&mut endpoints, &server_name, &config, &shutdown_tx).await;
+    let result = run_with_reconnect(endpoints.as_mut(), &server_name, &config, &shutdown_tx).await;
 
-    endpoints.wait_idle().await;
+    if let Some(pool) = endpoints.as_ref() {
+        pool.wait_idle().await;
+    }
     debug!("Run function completed");
     result
 }
@@ -110,7 +124,7 @@ const HAPPY_EYEBALLS_DELAY: Duration = Duration::from_millis(250);
 /// exponential backoff. Returns once shutdown is signalled, the session
 /// completes cleanly, or `max_retries` is exhausted.
 async fn run_with_reconnect(
-    endpoints: &mut EndpointPool<'_>,
+    endpoints: Option<&mut EndpointPool<'_>>,
     server_name: &str,
     config: &ClientConfig,
     shutdown_tx: &broadcast::Sender<()>,
@@ -123,6 +137,7 @@ async fn run_with_reconnect(
 
     let mut backoff = initial_backoff;
     let mut attempt: u32 = 0;
+    let mut endpoints = endpoints;
 
     loop {
         let mut shutdown_rx = shutdown_tx.subscribe();
@@ -132,8 +147,23 @@ async fn run_with_reconnect(
             config.server, server_name
         );
 
+        // Two connect strategies: direct (Happy Eyeballs across all resolved
+        // addresses, sharing QUIC endpoints across attempts) or via SOCKS5
+        // proxy (single fresh UDP ASSOCIATE, single address — the proxy
+        // handles routing). We dispatch here rather than threading an enum
+        // through `happy_eyeballs_connect` because the proxy path is simple
+        // enough that a parallel function reads more clearly.
         let connect_outcome = tokio::select! {
-            res = happy_eyeballs_connect(endpoints, &config.server.addrs, server_name) => Some(res),
+            res = async {
+                if let Some(proxy) = &config.proxy {
+                    proxied_connect(proxy, config, server_name).await
+                } else {
+                    let pool = endpoints
+                        .as_deref_mut()
+                        .expect("endpoint pool is built when no proxy is configured");
+                    happy_eyeballs_connect(pool, &config.server.addrs, server_name).await
+                }
+            } => Some(res),
             _ = shutdown_rx.recv() => return Ok(()),
         };
 
@@ -248,6 +278,34 @@ async fn happy_eyeballs_connect(
     ))
 }
 
+/// SOCKS5-proxied connect: do a fresh UDP ASSOCIATE handshake against the
+/// proxy, build a one-shot QUIC endpoint that wraps every datagram in SOCKS5
+/// UDP framing, and connect to the (proxy-relayed) server. Happy Eyeballs is
+/// not applicable here — the proxy is responsible for routing to the
+/// destination, so we just use the first resolved address as the SOCKS5
+/// `DST.ADDR` / `DST.PORT`.
+async fn proxied_connect(
+    proxy: &crate::common::proxy::ProxyConfig,
+    config: &ClientConfig,
+    server_name: &str,
+) -> Result<Connection> {
+    let server = config
+        .server
+        .addrs
+        .first()
+        .copied()
+        .ok_or_else(|| anyhow!("no candidate addresses to connect to"))?;
+    debug!(
+        target = %server,
+        proxy = %proxy,
+        "establishing SOCKS5 UDP ASSOCIATE for QUIC connection",
+    );
+    let endpoint =
+        create_client_endpoint_via_proxy(&config.tls, config.congestion, server, proxy).await?;
+    let connection = endpoint.connect(server, server_name)?.await?;
+    Ok(connection)
+}
+
 /// Double the current backoff up to the cap. Returns the cap if `max_backoff`
 /// is shorter than `current` (e.g. caller passed a tiny initial value).
 fn next_backoff(current: Duration, max_backoff: Duration) -> Duration {
@@ -355,7 +413,8 @@ async fn client_accept_dynamic_reverse_remote(quic_connection: Connection) -> Re
     let (mut send, mut recv) = stream;
 
     tokio::spawn(async move {
-        let dynamic_remote = server_receive_remote_request(&mut send, &mut recv, true).await?;
+        let dynamic_remote =
+            server_receive_remote_request(&mut send, &mut recv, true, true).await?;
         let remote_display = dynamic_remote.to_string();
 
         async {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,3 +1,4 @@
+pub mod proxy;
 pub mod quic;
 pub mod remote;
 pub mod socks;

--- a/src/common/proxy.rs
+++ b/src/common/proxy.rs
@@ -1,0 +1,698 @@
+//! Client-side outbound proxy support.
+//!
+//! Today this is **SOCKS5 with UDP ASSOCIATE only**. QUIC runs over UDP, so
+//! the only proxy protocol that can carry it natively without protocol
+//! changes is SOCKS5's UDP ASSOCIATE (RFC 1928 §4 / §7). HTTP `CONNECT` is
+//! TCP-only and would require a separate TCP transport for QUIC (see the
+//! "WebSocket fallback" entry on the README roadmap); MASQUE / RFC 9298
+//! `CONNECT-UDP` would require an HTTP/3 client. Both are out of scope for
+//! this initial revision.
+//!
+//! ## How it works
+//!
+//! 1. Open a TCP connection to the SOCKS5 proxy and complete the no-auth or
+//!    user/pass handshake.
+//! 2. Send `UDP ASSOCIATE` (CMD=0x03). The proxy replies with a `BND.ADDR` /
+//!    `BND.PORT` — that's the UDP relay endpoint we'll send all our QUIC
+//!    datagrams to.
+//! 3. Bind a local UDP socket and wrap it in [`Socks5UdpSocket`], an
+//!    [`quinn::AsyncUdpSocket`] adapter that:
+//!    - on **send**: prepends the SOCKS5 UDP datagram header
+//!      (`RSV=0, FRAG=0, ATYP, DST.ADDR, DST.PORT`) pointing at the real QUIC
+//!      server and forwards the packet to `BND.ADDR:BND.PORT`.
+//!    - on **recv**: strips the header, verifies the embedded source matches
+//!      the QUIC server we expect, and hands the inner payload up to quinn
+//!      tagged as if it had come straight from the server.
+//! 4. The TCP control connection is **kept alive** for the lifetime of the
+//!    socket — RFC 1928 §6 specifies that the UDP association ends when the
+//!    associated TCP connection terminates, so we hold the `TcpStream`
+//!    inside [`Socks5UdpSocket`] until the QUIC endpoint is dropped.
+//!
+//! ## Limitations of this minimum-viable implementation
+//!
+//! - GSO/GRO are disabled (single packet per syscall) — the SOCKS5 UDP
+//!   header is per-packet, so multi-segment offload would require
+//!   custom batching.
+//! - Per-send `Vec` allocation for the wrapped buffer; not visible in
+//!   profiles next to the proxy hop itself but worth optimizing if
+//!   anyone cares about high-pps SOCKS-tunneled QUIC.
+//! - DNS is resolved client-side (`socks5://`); `socks5h://` (proxy-side
+//!   resolution, ATYP=domain) is not yet plumbed through.
+
+use std::fmt;
+use std::io;
+use std::net::{IpAddr, SocketAddr};
+use std::pin::Pin;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use anyhow::{anyhow, bail, Context as _, Result};
+use quinn::{AsyncUdpSocket, UdpPoller};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpStream, UdpSocket};
+use tracing::{debug, warn};
+
+/// SOCKS5 UDP datagram header overhead for an IPv4 destination.
+/// Layout: RSV(2) + FRAG(1) + ATYP(1) + DST.ADDR(4) + DST.PORT(2).
+const SOCKS5_UDP_HEADER_IPV4_LEN: usize = 10;
+/// SOCKS5 UDP datagram header overhead for an IPv6 destination.
+/// Layout: RSV(2) + FRAG(1) + ATYP(1) + DST.ADDR(16) + DST.PORT(2).
+const SOCKS5_UDP_HEADER_IPV6_LEN: usize = 22;
+
+/// Outbound proxy configuration the client should route its QUIC connection
+/// through. Today only [`ProxyConfig::Socks5`] is supported.
+#[derive(Debug, Clone)]
+pub enum ProxyConfig {
+    /// SOCKS5 (RFC 1928) with UDP ASSOCIATE. `addr` is the proxy's `host:port`
+    /// (the host may be a DNS name or IP literal). `auth`, if present, is the
+    /// `(username, password)` pair for the username/password sub-negotiation
+    /// (RFC 1929).
+    Socks5 {
+        addr: String,
+        auth: Option<(String, String)>,
+    },
+}
+
+impl fmt::Display for ProxyConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProxyConfig::Socks5 { addr, auth } => {
+                if auth.is_some() {
+                    // Don't print the password.
+                    write!(f, "socks5://<auth>@{addr}")
+                } else {
+                    write!(f, "socks5://{addr}")
+                }
+            }
+        }
+    }
+}
+
+impl FromStr for ProxyConfig {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        // We accept `socks5://`, `socks://` (alias for socks5), and tolerate a
+        // bare `host:port` (assumed SOCKS5 — chisel does the same to be
+        // friendly to operators copy-pasting from a config).
+        let after_scheme = if let Some(rest) = s.strip_prefix("socks5://") {
+            rest
+        } else if let Some(rest) = s.strip_prefix("socks://") {
+            rest
+        } else if s.contains("://") {
+            return Err(format!(
+                "unsupported proxy scheme in `{s}`: only socks5:// is supported in this release"
+            ));
+        } else {
+            s
+        };
+
+        let (auth, addr) = match after_scheme.rsplit_once('@') {
+            Some((creds, addr)) => {
+                let (user, pass) = creds.split_once(':').ok_or_else(|| {
+                    format!("malformed proxy auth in `{s}` (expected user:pass@host:port)")
+                })?;
+                (Some((user.to_string(), pass.to_string())), addr)
+            }
+            None => (None, after_scheme),
+        };
+
+        if addr.is_empty() {
+            return Err(format!("proxy address is empty in `{s}`"));
+        }
+        // Quick sanity check: address must contain a port. We don't fully
+        // resolve it here — the tcp connect later will surface a clearer error
+        // if it's malformed.
+        if !addr.contains(':') {
+            return Err(format!(
+                "proxy address `{addr}` is missing a port (expected host:port)"
+            ));
+        }
+
+        Ok(ProxyConfig::Socks5 {
+            addr: addr.to_string(),
+            auth,
+        })
+    }
+}
+
+/// Result of a successful SOCKS5 UDP ASSOCIATE handshake.
+struct UdpAssociation {
+    /// The TCP control connection to the proxy. Must be held alive for the
+    /// lifetime of the UDP relay (RFC 1928 §6).
+    tcp: TcpStream,
+    /// The proxy's UDP relay endpoint. All datagrams we want forwarded must
+    /// be sent here, prefixed with the SOCKS5 UDP header.
+    relay: SocketAddr,
+}
+
+/// Open a TCP connection to the SOCKS5 proxy at `proxy_addr`, perform the
+/// no-auth / username-password handshake, and issue a UDP ASSOCIATE for the
+/// given `target` server. Returns the held-open TCP control connection plus
+/// the UDP relay address the proxy assigned.
+async fn establish_socks5_udp_associate(
+    proxy_addr: &str,
+    auth: Option<&(String, String)>,
+    target: SocketAddr,
+) -> Result<UdpAssociation> {
+    let mut tcp = TcpStream::connect(proxy_addr)
+        .await
+        .with_context(|| format!("failed to connect to SOCKS5 proxy at {proxy_addr}"))?;
+
+    // Greeting: VER=5, NMETHODS, METHODS[]. We always offer no-auth (0x00),
+    // and additionally offer user/pass (0x02) when the user supplied creds.
+    if auth.is_some() {
+        tcp.write_all(&[0x05, 0x02, 0x00, 0x02]).await?;
+    } else {
+        tcp.write_all(&[0x05, 0x01, 0x00]).await?;
+    }
+    let mut method_reply = [0u8; 2];
+    tcp.read_exact(&mut method_reply).await?;
+    if method_reply[0] != 0x05 {
+        bail!(
+            "SOCKS5 proxy returned bad version byte 0x{:02x}",
+            method_reply[0]
+        );
+    }
+    match method_reply[1] {
+        0x00 => {} // no auth selected
+        0x02 => {
+            let (user, pass) = auth.ok_or_else(|| {
+                anyhow!("SOCKS5 proxy demanded user/pass auth but none was configured")
+            })?;
+            socks5_userpass_auth(&mut tcp, user, pass).await?;
+        }
+        0xFF => bail!("SOCKS5 proxy refused all offered auth methods"),
+        m => bail!("SOCKS5 proxy selected unsupported auth method 0x{m:02x}"),
+    }
+
+    // UDP ASSOCIATE. Per RFC 1928 §4, DST.ADDR/DST.PORT here is the address
+    // the *client* will be sending datagrams from, and SHOULD be set to all
+    // zeros if not known — many clients (curl, ssh, chisel) do exactly that.
+    // The proxy uses it as a hint to filter incoming traffic to the relay.
+    tcp.write_all(&[
+        0x05, 0x03, 0x00, 0x01, // VER, CMD=UDP_ASSOCIATE, RSV, ATYP=IPv4
+        0, 0, 0, 0, // DST.ADDR = 0.0.0.0
+        0, 0, // DST.PORT = 0
+    ])
+    .await?;
+
+    // Reply: VER, REP, RSV, ATYP, BND.ADDR, BND.PORT.
+    let mut head = [0u8; 4];
+    tcp.read_exact(&mut head).await?;
+    if head[0] != 0x05 {
+        bail!("SOCKS5 reply has bad version byte 0x{:02x}", head[0]);
+    }
+    if head[1] != 0x00 {
+        bail!(
+            "SOCKS5 UDP ASSOCIATE failed with REP=0x{:02x} ({})",
+            head[1],
+            socks5_reply_meaning(head[1])
+        );
+    }
+    let bnd_ip: IpAddr = match head[3] {
+        0x01 => {
+            let mut o = [0u8; 4];
+            tcp.read_exact(&mut o).await?;
+            IpAddr::V4(o.into())
+        }
+        0x04 => {
+            let mut o = [0u8; 16];
+            tcp.read_exact(&mut o).await?;
+            IpAddr::V6(std::net::Ipv6Addr::from(o))
+        }
+        0x03 => {
+            // Domain — we'd have to resolve it. Most proxies return an IP
+            // literal here; when they don't, fall back to the proxy's TCP
+            // peer IP (RFC 1928 hint).
+            let mut len_buf = [0u8; 1];
+            tcp.read_exact(&mut len_buf).await?;
+            let mut name = vec![0u8; len_buf[0] as usize];
+            tcp.read_exact(&mut name).await?;
+            warn!(
+                "SOCKS5 proxy returned domain BND.ADDR `{}`; using proxy peer IP instead",
+                String::from_utf8_lossy(&name)
+            );
+            tcp.peer_addr()?.ip()
+        }
+        atyp => bail!("SOCKS5 reply has unsupported ATYP 0x{atyp:02x}"),
+    };
+    let mut port = [0u8; 2];
+    tcp.read_exact(&mut port).await?;
+    let bnd_port = u16::from_be_bytes(port);
+
+    // Some proxies reply with an unspecified BND.ADDR (0.0.0.0 / ::), meaning
+    // "use the same host you connected to me on" (RFC 1928 §6 hint). Resolve
+    // that defensively against the TCP peer IP.
+    let bnd_ip = if bnd_ip.is_unspecified() {
+        tcp.peer_addr()?.ip()
+    } else {
+        bnd_ip
+    };
+    let relay = SocketAddr::new(bnd_ip, bnd_port);
+
+    debug!(
+        proxy = %proxy_addr,
+        relay = %relay,
+        target = %target,
+        "SOCKS5 UDP ASSOCIATE established"
+    );
+    Ok(UdpAssociation { tcp, relay })
+}
+
+async fn socks5_userpass_auth(tcp: &mut TcpStream, user: &str, pass: &str) -> Result<()> {
+    let user_bytes = user.as_bytes();
+    let pass_bytes = pass.as_bytes();
+    if user_bytes.len() > u8::MAX as usize || pass_bytes.len() > u8::MAX as usize {
+        bail!("SOCKS5 user/pass auth: username or password exceeds 255 bytes");
+    }
+    let mut req = Vec::with_capacity(3 + user_bytes.len() + pass_bytes.len());
+    req.push(0x01); // sub-negotiation version
+    req.push(user_bytes.len() as u8);
+    req.extend_from_slice(user_bytes);
+    req.push(pass_bytes.len() as u8);
+    req.extend_from_slice(pass_bytes);
+    tcp.write_all(&req).await?;
+    let mut reply = [0u8; 2];
+    tcp.read_exact(&mut reply).await?;
+    if reply[0] != 0x01 {
+        bail!(
+            "SOCKS5 user/pass reply has bad sub-negotiation version 0x{:02x}",
+            reply[0]
+        );
+    }
+    if reply[1] != 0x00 {
+        bail!(
+            "SOCKS5 proxy rejected user/pass credentials (status 0x{:02x})",
+            reply[1]
+        );
+    }
+    Ok(())
+}
+
+fn socks5_reply_meaning(rep: u8) -> &'static str {
+    match rep {
+        0x00 => "succeeded",
+        0x01 => "general SOCKS server failure",
+        0x02 => "connection not allowed by ruleset",
+        0x03 => "network unreachable",
+        0x04 => "host unreachable",
+        0x05 => "connection refused",
+        0x06 => "TTL expired",
+        0x07 => "command not supported",
+        0x08 => "address type not supported",
+        _ => "unknown",
+    }
+}
+
+/// Build a SOCKS5 UDP datagram header pointing at `target`, returning the
+/// fully-formed wire buffer (header + payload). Public so unit tests can
+/// exercise it directly.
+fn wrap_socks5_udp(target: SocketAddr, payload: &[u8]) -> Vec<u8> {
+    let header_len = match target {
+        SocketAddr::V4(_) => SOCKS5_UDP_HEADER_IPV4_LEN,
+        SocketAddr::V6(_) => SOCKS5_UDP_HEADER_IPV6_LEN,
+    };
+    let mut buf = Vec::with_capacity(header_len + payload.len());
+    buf.extend_from_slice(&[0x00, 0x00, 0x00]); // RSV(2) + FRAG=0
+    match target {
+        SocketAddr::V4(v4) => {
+            buf.push(0x01);
+            buf.extend_from_slice(&v4.ip().octets());
+            buf.extend_from_slice(&v4.port().to_be_bytes());
+        }
+        SocketAddr::V6(v6) => {
+            buf.push(0x04);
+            buf.extend_from_slice(&v6.ip().octets());
+            buf.extend_from_slice(&v6.port().to_be_bytes());
+        }
+    }
+    buf.extend_from_slice(payload);
+    buf
+}
+
+/// Strip the SOCKS5 UDP header from `buf` (modifying it in place: shift the
+/// payload to the start of the buffer). Returns the address the inner
+/// datagram was sourced from and the length of the payload now at
+/// `buf[..payload_len]`. Returns `None` if the header is malformed or the
+/// fragment field is non-zero (RFC 1928 §7 — we reject fragmented datagrams,
+/// same as virtually every other SOCKS5 implementation in the wild).
+fn unwrap_socks5_udp_in_place(buf: &mut [u8]) -> Option<(SocketAddr, usize)> {
+    if buf.len() < 4 {
+        return None;
+    }
+    if buf[0] != 0x00 || buf[1] != 0x00 {
+        return None;
+    }
+    if buf[2] != 0x00 {
+        // FRAG != 0 — fragmented; reject.
+        return None;
+    }
+    let (src, header_len) = match buf[3] {
+        0x01 => {
+            if buf.len() < SOCKS5_UDP_HEADER_IPV4_LEN {
+                return None;
+            }
+            let ip = std::net::Ipv4Addr::new(buf[4], buf[5], buf[6], buf[7]);
+            let port = u16::from_be_bytes([buf[8], buf[9]]);
+            (
+                SocketAddr::new(IpAddr::V4(ip), port),
+                SOCKS5_UDP_HEADER_IPV4_LEN,
+            )
+        }
+        0x04 => {
+            if buf.len() < SOCKS5_UDP_HEADER_IPV6_LEN {
+                return None;
+            }
+            let mut o = [0u8; 16];
+            o.copy_from_slice(&buf[4..20]);
+            let ip = std::net::Ipv6Addr::from(o);
+            let port = u16::from_be_bytes([buf[20], buf[21]]);
+            (
+                SocketAddr::new(IpAddr::V6(ip), port),
+                SOCKS5_UDP_HEADER_IPV6_LEN,
+            )
+        }
+        // Domain (0x03) is legal in incoming SOCKS5 UDP but we never
+        // negotiated it — proxies that choose to send it back are non-conformant
+        // for this association. Ignore the packet.
+        _ => return None,
+    };
+    let payload_len = buf.len() - header_len;
+    buf.copy_within(header_len.., 0);
+    Some((src, payload_len))
+}
+
+/// Build a [`ProxyConfig`]-aware UDP "socket" suitable for handing to
+/// `quinn::Endpoint::new_with_abstract_socket`. Performs the SOCKS5 UDP
+/// ASSOCIATE handshake and binds the local UDP socket; returns a
+/// [`Socks5UdpSocket`] that wraps every outbound datagram in a SOCKS5 header
+/// pointing at `server` and unwraps every inbound one from the same.
+pub async fn create_socks5_proxied_socket(
+    proxy: &ProxyConfig,
+    server: SocketAddr,
+) -> Result<Arc<Socks5UdpSocket>> {
+    let ProxyConfig::Socks5 { addr, auth } = proxy;
+    let association = establish_socks5_udp_associate(addr, auth.as_ref(), server).await?;
+
+    // Bind a local UDP socket in the family of the proxy's relay. Most
+    // proxies relay over IPv4; if a future proxy uses v6 we follow.
+    let bind_addr: SocketAddr = match association.relay {
+        SocketAddr::V4(_) => "0.0.0.0:0".parse().expect("static"),
+        SocketAddr::V6(_) => "[::]:0".parse().expect("static"),
+    };
+    let udp = UdpSocket::bind(bind_addr)
+        .await
+        .with_context(|| format!("failed to bind local UDP socket {bind_addr}"))?;
+
+    // Spawn a background task that reads from the TCP control connection and
+    // logs when it terminates. The proxy normally never sends data on the
+    // control channel, but if it closes (e.g. relay revoked) the QUIC
+    // connection is now dead — better to surface that than to silently
+    // continue dropping packets.
+    let (tcp_keepalive_read, tcp_keepalive_write) = tokio::io::split(association.tcp);
+    let tcp_owned = TcpKeepalive::spawn(tcp_keepalive_read, tcp_keepalive_write);
+
+    Ok(Arc::new(Socks5UdpSocket {
+        udp,
+        relay: association.relay,
+        target: server,
+        _tcp: tcp_owned,
+    }))
+}
+
+/// Wraps [`tokio::net::UdpSocket`] to perform per-packet SOCKS5 UDP
+/// encapsulation/decapsulation. See module-level docs.
+#[derive(Debug)]
+pub struct Socks5UdpSocket {
+    udp: UdpSocket,
+    /// The proxy's UDP relay endpoint.
+    relay: SocketAddr,
+    /// The QUIC server address all wrapped datagrams target. quinn opens one
+    /// connection per endpoint in our usage, so this is fixed for the
+    /// lifetime of the socket.
+    target: SocketAddr,
+    /// Held only to keep the SOCKS5 control connection (and therefore the UDP
+    /// relay) alive. Dropped with the socket.
+    _tcp: TcpKeepalive,
+}
+
+impl AsyncUdpSocket for Socks5UdpSocket {
+    fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn UdpPoller>> {
+        Box::pin(Socks5UdpPoller {
+            socket: self.clone(),
+        })
+    }
+
+    fn try_send(&self, transmit: &quinn::udp::Transmit) -> io::Result<()> {
+        // quinn drives a single QUIC connection per endpoint here, so
+        // `transmit.destination` is the QUIC server we negotiated the UDP
+        // ASSOCIATE for. Defensively check anyway; if we ever accept a
+        // different destination, drop the packet rather than silently
+        // misroute it through the proxy.
+        if transmit.destination != self.target {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "Socks5UdpSocket received transmit for {} but relay is bound to {}",
+                    transmit.destination, self.target
+                ),
+            ));
+        }
+        let buf = wrap_socks5_udp(self.target, transmit.contents);
+        match self.udp.try_send_to(&buf, self.relay) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn poll_recv(
+        &self,
+        cx: &mut Context,
+        bufs: &mut [io::IoSliceMut<'_>],
+        meta: &mut [quinn::udp::RecvMeta],
+    ) -> Poll<io::Result<usize>> {
+        // GSO/GRO is disabled for this socket (max_*_segments = 1), so quinn
+        // hands us per-packet buffers. We process exactly one per call —
+        // simpler and good enough given the proxy hop dominates throughput.
+        if bufs.is_empty() || meta.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+        let buf = &mut bufs[0];
+        loop {
+            // ReadBuf wants &mut [MaybeUninit<u8>]; we have &mut [u8] — quinn
+            // pre-zeros / reuses the buffer, so it's already initialized
+            // memory we can safely view as a ReadBuf.
+            let mut read_buf = tokio::io::ReadBuf::new(buf);
+            match self.udp.poll_recv_from(cx, &mut read_buf) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Ready(Ok(src)) => {
+                    let n = read_buf.filled().len();
+                    if src != self.relay {
+                        // A datagram from somewhere other than the proxy's
+                        // relay endpoint — skip it. Most likely a stray
+                        // packet from a previous association, or a probe.
+                        debug!(
+                            "ignoring unexpected datagram from {} on SOCKS5-proxied socket",
+                            src
+                        );
+                        continue;
+                    }
+                    let used = &mut buf[..n];
+                    let Some((inner_src, payload_len)) = unwrap_socks5_udp_in_place(used) else {
+                        debug!("dropping malformed SOCKS5 UDP datagram (len={n})");
+                        continue;
+                    };
+                    if inner_src != self.target {
+                        debug!(
+                            "ignoring SOCKS5 datagram with inner src {} (expected {})",
+                            inner_src, self.target
+                        );
+                        continue;
+                    }
+                    meta[0] = quinn::udp::RecvMeta {
+                        addr: self.target,
+                        len: payload_len,
+                        stride: payload_len,
+                        ecn: None,
+                        dst_ip: None,
+                    };
+                    return Poll::Ready(Ok(1));
+                }
+            }
+        }
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.udp.local_addr()
+    }
+
+    fn max_transmit_segments(&self) -> usize {
+        1
+    }
+
+    fn max_receive_segments(&self) -> usize {
+        1
+    }
+
+    fn may_fragment(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug)]
+struct Socks5UdpPoller {
+    socket: Arc<Socks5UdpSocket>,
+}
+
+impl UdpPoller for Socks5UdpPoller {
+    fn poll_writable(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        self.socket.udp.poll_send_ready(cx)
+    }
+}
+
+/// Owns the two halves of the SOCKS5 control TCP connection and a background
+/// task that drains anything the proxy chooses to send back. Closes the TCP
+/// when dropped (which tears the UDP relay down on the proxy side per RFC
+/// 1928 §6).
+#[derive(Debug)]
+struct TcpKeepalive {
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl TcpKeepalive {
+    fn spawn(
+        mut read: tokio::io::ReadHalf<TcpStream>,
+        write: tokio::io::WriteHalf<TcpStream>,
+    ) -> Self {
+        let handle = tokio::spawn(async move {
+            let mut sink = [0u8; 64];
+            loop {
+                match read.read(&mut sink).await {
+                    Ok(0) => {
+                        debug!("SOCKS5 proxy closed the control TCP connection");
+                        break;
+                    }
+                    Ok(n) => debug!("SOCKS5 proxy sent {n} unexpected bytes on control channel"),
+                    Err(e) => {
+                        debug!("SOCKS5 control TCP read error: {e}");
+                        break;
+                    }
+                }
+            }
+            // Reuniting the halves drops the TCP cleanly. If the read half
+            // already errored the write half is already dead too.
+            drop(write);
+        });
+        Self { handle }
+    }
+}
+
+impl Drop for TcpKeepalive {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_socks5_no_auth() {
+        let p = ProxyConfig::from_str("socks5://example.com:1080").unwrap();
+        let ProxyConfig::Socks5 { addr, auth } = p;
+        assert_eq!(addr, "example.com:1080");
+        assert!(auth.is_none());
+    }
+
+    #[test]
+    fn parse_socks_alias_no_auth() {
+        let p = ProxyConfig::from_str("socks://10.0.0.1:9050").unwrap();
+        let ProxyConfig::Socks5 { addr, auth } = p;
+        assert_eq!(addr, "10.0.0.1:9050");
+        assert!(auth.is_none());
+    }
+
+    #[test]
+    fn parse_bare_host_port_defaults_to_socks5() {
+        let p = ProxyConfig::from_str("127.0.0.1:1080").unwrap();
+        let ProxyConfig::Socks5 { addr, auth } = p;
+        assert_eq!(addr, "127.0.0.1:1080");
+        assert!(auth.is_none());
+    }
+
+    #[test]
+    fn parse_socks5_with_auth() {
+        let p = ProxyConfig::from_str("socks5://alice:s3cret@proxy.example:1080").unwrap();
+        let ProxyConfig::Socks5 { addr, auth } = p;
+        assert_eq!(addr, "proxy.example:1080");
+        assert_eq!(auth, Some(("alice".to_string(), "s3cret".to_string())));
+    }
+
+    #[test]
+    fn parse_rejects_http_scheme() {
+        let err = ProxyConfig::from_str("http://proxy:8080").unwrap_err();
+        assert!(err.contains("only socks5://"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_rejects_missing_port() {
+        let err = ProxyConfig::from_str("socks5://proxy.example").unwrap_err();
+        assert!(err.contains("missing a port"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_rejects_malformed_auth() {
+        let err = ProxyConfig::from_str("socks5://noColon@proxy.example:1080").unwrap_err();
+        assert!(err.contains("malformed proxy auth"), "got: {err}");
+    }
+
+    #[test]
+    fn wrap_unwrap_ipv4_roundtrip() {
+        let target: SocketAddr = "1.2.3.4:5555".parse().unwrap();
+        let payload = b"hello quic packet";
+        let mut wire = wrap_socks5_udp(target, payload);
+        // wrap_socks5_udp produces header+payload; verify shape.
+        assert_eq!(&wire[..4], &[0, 0, 0, 0x01]);
+        assert_eq!(&wire[4..8], &[1, 2, 3, 4]);
+        assert_eq!(u16::from_be_bytes([wire[8], wire[9]]), 5555);
+        assert_eq!(&wire[10..], payload);
+
+        let (src, n) = unwrap_socks5_udp_in_place(&mut wire).unwrap();
+        assert_eq!(src, target);
+        assert_eq!(n, payload.len());
+        assert_eq!(&wire[..n], payload);
+    }
+
+    #[test]
+    fn wrap_unwrap_ipv6_roundtrip() {
+        let target: SocketAddr = "[2001:db8::1]:80".parse().unwrap();
+        let payload = b"v6 payload";
+        let mut wire = wrap_socks5_udp(target, payload);
+        assert_eq!(wire[3], 0x04);
+        let (src, n) = unwrap_socks5_udp_in_place(&mut wire).unwrap();
+        assert_eq!(src, target);
+        assert_eq!(&wire[..n], payload);
+    }
+
+    #[test]
+    fn unwrap_rejects_fragmented() {
+        let mut wire = vec![0, 0, 0x01, 0x01, 1, 2, 3, 4, 0, 80];
+        assert!(unwrap_socks5_udp_in_place(&mut wire).is_none());
+    }
+
+    #[test]
+    fn unwrap_rejects_short_buffer() {
+        let mut wire = vec![0, 0, 0, 0x01, 1, 2];
+        assert!(unwrap_socks5_udp_in_place(&mut wire).is_none());
+    }
+
+    #[test]
+    fn unwrap_rejects_unknown_atyp() {
+        let mut wire = vec![0, 0, 0, 0xFF, 0, 0, 0, 0, 0, 0];
+        assert!(unwrap_socks5_udp_in_place(&mut wire).is_none());
+    }
+}

--- a/src/common/quic.rs
+++ b/src/common/quic.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 use std::{sync::Arc, time::Duration};
 use tracing::{debug, info, warn};
 
+use crate::common::proxy::{create_socks5_proxied_socket, ProxyConfig};
 use crate::common::tls::{cert_sha256, format_fingerprint, ClientTlsConfig, ServerTlsConfig};
 
 // Use the HTTP/3 ALPN identifier so handshake fingerprints look like a real
@@ -113,6 +114,34 @@ pub fn create_client_endpoint(
         SocketAddr::V6(_) => "[::]:0".parse()?,
     };
     let mut endpoint = Endpoint::client(bind_addr)?;
+    endpoint.set_default_client_config(client_config);
+    Ok(endpoint)
+}
+
+/// Like [`create_client_endpoint`], but routes every QUIC datagram through a
+/// SOCKS5 proxy via UDP ASSOCIATE. Async because the SOCKS5 control-plane
+/// handshake is performed up-front; the returned endpoint is single-use
+/// (one QUIC connection per association — disconnect tears the proxy
+/// relay down, requiring a fresh handshake on reconnect).
+pub async fn create_client_endpoint_via_proxy(
+    tls: &ClientTlsConfig,
+    congestion: Congestion,
+    server_addr: SocketAddr,
+    proxy: &ProxyConfig,
+) -> Result<Endpoint> {
+    use quinn::{EndpointConfig, TokioRuntime};
+    use std::sync::Arc;
+
+    let mut client_config = build_quic_client_config(tls)?;
+    client_config.transport_config(build_transport_config(congestion));
+
+    let socket = create_socks5_proxied_socket(proxy, server_addr).await?;
+    let mut endpoint = Endpoint::new_with_abstract_socket(
+        EndpointConfig::default(),
+        None,
+        socket,
+        Arc::new(TokioRuntime),
+    )?;
     endpoint.set_default_client_config(client_config);
     Ok(endpoint)
 }

--- a/src/common/tunnel.rs
+++ b/src/common/tunnel.rs
@@ -67,6 +67,7 @@ pub async fn server_receive_remote_request(
     send_channel: &mut SendStream,
     recv_channel: &mut RecvStream,
     allow_reverse: bool,
+    allow_socks: bool,
 ) -> Result<RemoteRequest> {
     let request: RemoteRequest = read_framed(recv_channel).await?;
     debug!("received remote request: {}", request);
@@ -76,6 +77,18 @@ pub async fn server_receive_remote_request(
             RemoteResponse::RemoteFailed(String::from("Reverse remotes are not allowed"));
         write_framed(send_channel, &response).await?;
         return Err(anyhow!("Reverse remotes are not allowed"));
+    }
+
+    // Reverse-SOCKS5 is the only path that surfaces here as a SOCKS-typed
+    // request — forward `socks` is decomposed client-side into per-target
+    // dynamic TCP/UDP requests, which look like normal forward tunnels on
+    // the wire and so can't be gated here. The check is therefore purely
+    // about preventing a connecting client from making the *server* spin
+    // up a SOCKS listener exposing the server's network.
+    if request.is_socks() && !allow_socks {
+        let response = RemoteResponse::RemoteFailed(String::from("SOCKS5 remotes are not allowed"));
+        write_framed(send_channel, &response).await?;
+        return Err(anyhow!("SOCKS5 remotes are not allowed"));
     }
 
     write_framed(send_channel, &RemoteResponse::RemoteOk).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
+use common::proxy::ProxyConfig;
 use common::quic::Congestion;
 use common::remote::RemoteRequest;
 use common::tls::{ClientTlsConfig, ServerTlsConfig};
@@ -19,6 +20,14 @@ pub struct ServerConfig {
     pub host: IpAddr,
     pub port: u16,
     pub allow_reverse: bool,
+    /// Whether to allow clients to request a reverse SOCKS5 dynamic tunnel
+    /// (`R:socks`). When `false` (the default), reverse-SOCKS requests are
+    /// rejected at the control-plane handshake so the server never spins up
+    /// a SOCKS listener on behalf of a client. Forward SOCKS (`socks`)
+    /// decomposes into per-target dynamic TCP/UDP on the wire and is *not*
+    /// gated by this flag — see the README's "Security & access control"
+    /// roadmap for the planned full-ACL story.
+    pub allow_socks: bool,
     pub tls: ServerTlsConfig,
     pub congestion: Congestion,
     /// Maximum number of concurrent client *connections* the server will
@@ -98,6 +107,11 @@ pub struct ClientConfig {
     pub tls: ClientTlsConfig,
     pub congestion: Congestion,
     pub reconnect: ReconnectConfig,
+    /// Optional outbound proxy for the QUIC connection. Today only
+    /// `socks5://[user:pass@]host:port` is supported (carries QUIC over
+    /// SOCKS5 UDP ASSOCIATE per RFC 1928 §4). `None` means connect
+    /// directly.
+    pub proxy: Option<ProxyConfig>,
 }
 
 /// Controls the client's reconnect-on-disconnect behaviour.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::crate_version;
 use clap::error::ErrorKind;
 use clap::{Args as ClapArgs, CommandFactory, Parser, Subcommand, ValueEnum};
 use rusnel::cert;
+use rusnel::common::proxy::ProxyConfig;
 use rusnel::common::quic::Congestion;
 use rusnel::common::remote::RemoteRequest;
 use rusnel::common::tls::{parse_fingerprint, ClientTlsConfig, ServerTlsConfig};
@@ -152,6 +153,10 @@ fn parse_remote(s: &str) -> Result<RemoteRequest, String> {
     RemoteRequest::from_str(s).map_err(|e| format!("invalid remote `{s}`: {e}"))
 }
 
+fn parse_proxy(s: &str) -> Result<ProxyConfig, String> {
+    ProxyConfig::from_str(s)
+}
+
 /// Rusnel is a fast tcp/udp multiplexed tunnel.
 #[derive(Parser)]
 #[command(name = "Rusnel", version = crate_version!())]
@@ -182,6 +187,15 @@ enum Mode {
         /// Allow clients to specify reverse port forwarding remotes.
         #[arg(long, default_value_t = false)]
         allow_reverse: bool,
+
+        /// Allow clients to request a reverse SOCKS5 dynamic tunnel
+        /// (`R:socks`). When unset (the default), the server rejects
+        /// reverse-SOCKS requests at the control-plane handshake instead
+        /// of binding a local SOCKS listener that exposes the server's
+        /// network to the connecting client. Forward SOCKS (`socks`) is
+        /// driven entirely by the client and is not gated by this flag.
+        #[arg(long, default_value_t = false)]
+        allow_socks: bool,
 
         /// Disable all TLS authentication. Uses an ephemeral self-signed
         /// certificate and accepts any client. MITM-vulnerable; for testing
@@ -350,6 +364,16 @@ sharing <remote-host>:<remote-port> from the client to the server\'s <local-host
         /// value (default 300s, matching chisel).
         #[arg(long, value_name = "SECONDS", default_value = "300", value_parser = parse_duration_secs)]
         max_retry_interval: Duration,
+
+        /// Route the QUIC connection through an outbound proxy. Today only
+        /// SOCKS5 with UDP ASSOCIATE (RFC 1928 §4) is supported — QUIC is
+        /// UDP-based, so HTTP CONNECT cannot carry it. Accepts
+        /// `socks5://[user:pass@]host:port` (`socks://` is an alias). The
+        /// proxy must permit UDP ASSOCIATE; many corporate / hotel HTTP
+        /// proxies do not. A fresh UDP association is opened on every
+        /// (re)connect.
+        #[arg(long, value_name = "URL", value_parser = parse_proxy)]
+        proxy: Option<ProxyConfig>,
 
         /// enable verbose logging
         #[arg(short('v'), long("verbose"), default_value_t = false)]
@@ -594,6 +618,7 @@ fn main() {
             host,
             port,
             allow_reverse,
+            allow_socks,
             insecure,
             tls_self_signed,
             tls_state_dir,
@@ -634,6 +659,7 @@ fn main() {
                 host,
                 port,
                 allow_reverse,
+                allow_socks,
                 tls,
                 congestion: congestion.into(),
                 max_connections: if max_connections == 0 {
@@ -657,6 +683,7 @@ fn main() {
             congestion,
             max_retry_count,
             max_retry_interval,
+            proxy,
             is_verbose,
             is_debug,
         } => {
@@ -700,6 +727,7 @@ fn main() {
                 tls,
                 congestion: congestion.into(),
                 reconnect,
+                proxy,
             };
             debug!("Initialized client with config: {:?}", client_config);
             run_client(client_config);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -81,7 +81,7 @@ pub async fn run_async(config: ServerConfig) -> Result<()> {
                     None
                 };
 
-                let fut = handle_client_connection(conn, config.allow_reverse);
+                let fut = handle_client_connection(conn, config.allow_reverse, config.allow_socks);
                 tokio::spawn(
                     async move {
                         info!("client connected");
@@ -110,7 +110,11 @@ pub async fn run_async(config: ServerConfig) -> Result<()> {
 /// local port: without the abort, those tasks would keep accepting forever
 /// against a dead QUIC connection, holding the port until the server
 /// process exited.
-async fn handle_client_connection(conn: quinn::Incoming, allow_reverse: bool) -> Result<String> {
+async fn handle_client_connection(
+    conn: quinn::Incoming,
+    allow_reverse: bool,
+    allow_socks: bool,
+) -> Result<String> {
     let connection = conn.await?;
     let mut tunnels: JoinSet<()> = JoinSet::new();
 
@@ -163,7 +167,7 @@ async fn handle_client_connection(conn: quinn::Incoming, allow_reverse: bool) ->
             Ok(s) => s,
         };
 
-        let fut = handle_remote_stream(quic_connection, stream, allow_reverse);
+        let fut = handle_remote_stream(quic_connection, stream, allow_reverse, allow_socks);
         tunnels.spawn(async move {
             if let Err(e) = fut.await {
                 error!("failed: {}", e);
@@ -186,8 +190,10 @@ async fn handle_remote_stream(
     quic_connection: Connection,
     (mut send, mut recv): (quinn::SendStream, quinn::RecvStream),
     allow_reverse: bool,
+    allow_socks: bool,
 ) -> Result<()> {
-    let request = server_receive_remote_request(&mut send, &mut recv, allow_reverse).await?;
+    let request =
+        server_receive_remote_request(&mut send, &mut recv, allow_reverse, allow_socks).await?;
     let remote_display = request.to_string();
 
     async {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -98,6 +98,7 @@ pub fn server_config_with_tls(
         host: IpAddr::V4(Ipv4Addr::LOCALHOST),
         port,
         allow_reverse,
+        allow_socks: true,
         tls,
         congestion: Default::default(),
         max_connections: None,
@@ -123,6 +124,7 @@ pub fn client_config_with_tls(
         tls,
         congestion: Default::default(),
         reconnect: ReconnectConfig::default(),
+        proxy: None,
     }
 }
 

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -1,0 +1,267 @@
+//! Integration tests for `--proxy socks5://...` client support.
+//!
+//! These tests stand up a *minimal* in-process SOCKS5 UDP relay (just enough
+//! of RFC 1928 to satisfy Rusnel's client) and verify that a Rusnel client
+//! configured with `proxy = Some(...)` can complete the QUIC handshake with
+//! a real Rusnel server, and that bidirectional TCP traffic flows through
+//! the resulting tunnel as if no proxy were involved.
+//!
+//! The relay sits between the client's UDP socket and the server's UDP
+//! socket, so it exercises the full SOCKS5 UDP framing path — wrap on the
+//! way out, unwrap on the way in.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use rusnel::common::proxy::ProxyConfig;
+use rusnel::common::remote::RemoteRequest;
+use rusnel::common::tls::ClientTlsConfig;
+use rusnel::{ClientConfig, ReconnectConfig, ServerEndpoint};
+use std::str::FromStr;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream, UdpSocket};
+use tokio::sync::Mutex;
+
+mod common;
+use common::{
+    get_available_port, get_available_udp_port, init_crypto, server_config, STARTUP_DELAY,
+    TEST_TIMEOUT,
+};
+
+/// Minimal SOCKS5 UDP relay sufficient for Rusnel's client. Returns the
+/// proxy's TCP listen address (what `--proxy socks5://addr` should point
+/// to) and a tokio task handle that owns the relay.
+async fn spawn_socks5_relay() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let proxy_tcp_port = get_available_port();
+    let proxy_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), proxy_tcp_port);
+    let listener = TcpListener::bind(proxy_addr).await.unwrap();
+
+    let handle = tokio::spawn(async move {
+        loop {
+            let (mut tcp, _peer) = match listener.accept().await {
+                Ok(x) => x,
+                Err(_) => return,
+            };
+            tokio::spawn(async move {
+                if let Err(e) = handle_socks5_client(&mut tcp).await {
+                    eprintln!("relay client handler ended: {e}");
+                }
+            });
+        }
+    });
+    (proxy_addr, handle)
+}
+
+async fn handle_socks5_client(tcp: &mut TcpStream) -> std::io::Result<()> {
+    // Greeting: VER=5, NMETHODS, METHODS[]
+    let mut head = [0u8; 2];
+    tcp.read_exact(&mut head).await?;
+    assert_eq!(head[0], 0x05);
+    let mut methods = vec![0u8; head[1] as usize];
+    tcp.read_exact(&mut methods).await?;
+    // Always reply "no auth selected".
+    tcp.write_all(&[0x05, 0x00]).await?;
+
+    // Request: VER, CMD, RSV, ATYP, DST.ADDR, DST.PORT
+    let mut req_head = [0u8; 4];
+    tcp.read_exact(&mut req_head).await?;
+    assert_eq!(req_head[0], 0x05);
+    assert_eq!(req_head[1], 0x03, "expected UDP ASSOCIATE");
+    let _addr_bytes = match req_head[3] {
+        0x01 => {
+            let mut o = [0u8; 4];
+            tcp.read_exact(&mut o).await?;
+            o.to_vec()
+        }
+        0x04 => {
+            let mut o = [0u8; 16];
+            tcp.read_exact(&mut o).await?;
+            o.to_vec()
+        }
+        atyp => panic!("unexpected ATYP {atyp}"),
+    };
+    let mut port_bytes = [0u8; 2];
+    tcp.read_exact(&mut port_bytes).await?;
+
+    // Bind a UDP relay socket. Reply BND.ADDR/BND.PORT pointing at it.
+    let relay_udp = UdpSocket::bind("127.0.0.1:0").await?;
+    let relay_addr = relay_udp.local_addr()?;
+    let SocketAddr::V4(v4) = relay_addr else {
+        panic!("relay must bind v4 in this test");
+    };
+    let mut reply = vec![0x05, 0x00, 0x00, 0x01];
+    reply.extend_from_slice(&v4.ip().octets());
+    reply.extend_from_slice(&v4.port().to_be_bytes());
+    tcp.write_all(&reply).await?;
+
+    // Now run the relay. Two state pieces:
+    //   - client_addr: the UDP source we'll forward server replies back to.
+    //   - last_target: the last embedded DST.ADDR/DST.PORT the client sent.
+    let relay_udp = Arc::new(relay_udp);
+    let client_addr: Arc<Mutex<Option<SocketAddr>>> = Arc::new(Mutex::new(None));
+    let last_target: Arc<Mutex<Option<SocketAddr>>> = Arc::new(Mutex::new(None));
+
+    let relay_pump = {
+        let relay_udp = relay_udp.clone();
+        let client_addr = client_addr.clone();
+        let last_target = last_target.clone();
+        tokio::spawn(async move {
+            let mut buf = vec![0u8; 65535];
+            loop {
+                let (n, src) = match relay_udp.recv_from(&mut buf).await {
+                    Ok(x) => x,
+                    Err(_) => return,
+                };
+                let pkt = &buf[..n];
+                if pkt.len() < 10 {
+                    continue;
+                }
+                // Direction: from client (client wraps with SOCKS5 header) vs
+                // from upstream server (raw QUIC). We disambiguate by source:
+                // if it matches the recorded client_addr we treat it as
+                // outbound (unwrap + forward); otherwise we treat it as a
+                // reply from a target server (wrap + send to client).
+                let is_from_client = {
+                    let guard = client_addr.lock().await;
+                    matches!(*guard, Some(addr) if addr == src)
+                };
+                if is_from_client || client_addr.lock().await.is_none() {
+                    // Outbound from client. Record client_addr if first time.
+                    {
+                        let mut guard = client_addr.lock().await;
+                        if guard.is_none() {
+                            *guard = Some(src);
+                        }
+                    }
+                    if pkt[0] != 0 || pkt[1] != 0 || pkt[2] != 0 {
+                        continue;
+                    }
+                    let target = match pkt[3] {
+                        0x01 if pkt.len() >= 10 => SocketAddr::new(
+                            IpAddr::V4(Ipv4Addr::new(pkt[4], pkt[5], pkt[6], pkt[7])),
+                            u16::from_be_bytes([pkt[8], pkt[9]]),
+                        ),
+                        _ => continue,
+                    };
+                    {
+                        let mut guard = last_target.lock().await;
+                        *guard = Some(target);
+                    }
+                    let payload = &pkt[10..];
+                    let _ = relay_udp.send_to(payload, target).await;
+                } else {
+                    // Inbound from a target server. Wrap with SOCKS5 header
+                    // (using the src as DST.ADDR/DST.PORT) and forward to
+                    // the recorded client.
+                    let client = match *client_addr.lock().await {
+                        Some(c) => c,
+                        None => continue,
+                    };
+                    let SocketAddr::V4(src_v4) = src else {
+                        continue;
+                    };
+                    let mut wrapped = Vec::with_capacity(10 + pkt.len());
+                    wrapped.extend_from_slice(&[0, 0, 0, 0x01]);
+                    wrapped.extend_from_slice(&src_v4.ip().octets());
+                    wrapped.extend_from_slice(&src_v4.port().to_be_bytes());
+                    wrapped.extend_from_slice(pkt);
+                    let _ = relay_udp.send_to(&wrapped, client).await;
+                }
+                // Re-borrow `last_target` once at end to keep clippy happy
+                // about unused variables in the no-target branch.
+                let _ = &last_target;
+            }
+        })
+    };
+
+    // Block until the TCP control connection closes (per RFC 1928 §6).
+    let mut sink = [0u8; 16];
+    let _ = tcp.read(&mut sink).await;
+    relay_pump.abort();
+    Ok(())
+}
+
+/// Spawn a tiny TCP echo server and return its address.
+async fn spawn_tcp_echo() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (mut conn, _) = match listener.accept().await {
+                Ok(x) => x,
+                Err(_) => return,
+            };
+            tokio::spawn(async move {
+                let (mut r, mut w) = conn.split();
+                let _ = tokio::io::copy(&mut r, &mut w).await;
+            });
+        }
+    });
+    addr
+}
+
+#[tokio::test]
+async fn tcp_forward_through_socks5_proxy() {
+    init_crypto();
+
+    let server_port = get_available_udp_port();
+    let local_port = get_available_port();
+    let echo_addr = spawn_tcp_echo().await;
+
+    // Server.
+    let sc = server_config(server_port, false);
+    let server_handle = tokio::spawn(async move {
+        let _ = rusnel::server::run_async(sc).await;
+    });
+    tokio::time::sleep(STARTUP_DELAY).await;
+
+    // SOCKS5 proxy.
+    let (proxy_addr, _proxy_handle) = spawn_socks5_relay().await;
+
+    // Client routed through the proxy.
+    let server_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), server_port);
+    let remote_spec = format!("{}:{}:{}/tcp", local_port, echo_addr.ip(), echo_addr.port());
+    let remote = RemoteRequest::from_str(&remote_spec).unwrap();
+    let cc = ClientConfig {
+        server: ServerEndpoint {
+            addrs: vec![server_addr],
+            host: server_addr.ip().to_string(),
+        },
+        remotes: vec![remote],
+        tls: ClientTlsConfig::Insecure,
+        congestion: Default::default(),
+        reconnect: ReconnectConfig::default(),
+        proxy: Some(ProxyConfig::from_str(&format!("socks5://{proxy_addr}")).unwrap()),
+    };
+    let client_handle = tokio::spawn(async move {
+        let _ = rusnel::client::run_async(cc).await;
+    });
+    // The client has to (a) open a TCP connection to the proxy, (b) do the
+    // SOCKS5 handshake, (c) complete the QUIC TLS handshake through the
+    // relay, (d) bind the local TCP listener for the forward. Give it a bit
+    // more time than the no-proxy path.
+    tokio::time::sleep(STARTUP_DELAY * 3).await;
+
+    // Talk to the forwarded port and make sure the bytes round-trip.
+    let result = tokio::time::timeout(TEST_TIMEOUT, async {
+        let mut conn = TcpStream::connect(("127.0.0.1", local_port))
+            .await
+            .expect("connect to local forward");
+        conn.write_all(b"hello via socks5 proxy")
+            .await
+            .expect("write");
+        let mut got = vec![0u8; 22];
+        conn.read_exact(&mut got).await.expect("read echo");
+        got
+    })
+    .await
+    .expect("timed out");
+
+    assert_eq!(&result[..], b"hello via socks5 proxy");
+
+    server_handle.abort();
+    client_handle.abort();
+    let _ = tokio::time::timeout(Duration::from_millis(200), server_handle).await;
+    let _ = tokio::time::timeout(Duration::from_millis(200), client_handle).await;
+}

--- a/tests/reconnect.rs
+++ b/tests/reconnect.rs
@@ -119,7 +119,7 @@ async fn handle_test_stream(
 ) {
     use rusnel::common::tcp::tunnel_tcp_server;
     use rusnel::common::tunnel::server_receive_remote_request;
-    let request = match server_receive_remote_request(&mut send, &mut recv, false).await {
+    let request = match server_receive_remote_request(&mut send, &mut recv, false, false).await {
         Ok(r) => r,
         Err(e) => {
             info!("control handshake failed: {e}");


### PR DESCRIPTION
## Summary

Two new flags from the README roadmap, both gated behind explicit opt-in for safety:

- **`--allow-socks` (server)** — default-deny gate for reverse-SOCKS5 (`R:socks` / `R:port:socks`). Without it the server now refuses reverse-SOCKS at the control-plane handshake instead of silently exposing its network. Mirrors `--allow-reverse` semantics. Forward `socks` decomposes into per-target dynamic TCP/UDP on the wire and is intentionally **not** gated by this flag — see the new \"Security & access control\" roadmap section in the README for the full ACL story.

- **`--proxy socks5://[user:pass@]host:port` (client)** — routes the QUIC connection through a SOCKS5 proxy via UDP ASSOCIATE (RFC 1928 §4). New `rusnel::common::proxy` module with:
  - `ProxyConfig` URL parser (`socks5://`, `socks://` alias, bare `host:port`, optional `user:pass@` per RFC 1929).
  - SOCKS5 control-plane handshake (no-auth + user/pass).
  - `Socks5UdpSocket` adapter implementing `quinn::AsyncUdpSocket`, wrapping every outbound QUIC datagram in `RSV/FRAG/ATYP/DST.ADDR/DST.PORT` framing and unwrapping every inbound one. The TCP control connection is held open inside the socket for the lifetime of the relay (RFC 1928 §6).
  - Client-side: bypasses Happy Eyeballs and the cross-attempt endpoint pool when proxied (the proxy owns routing); each reconnect opens a fresh UDP association.

HTTP CONNECT is intentionally **not** supported in this release — it cannot carry UDP/QUIC. The path that would unlock HTTP/SOCKS-CONNECT proxies is the WebSocket-fallback transport tracked separately in the README roadmap.

## Test plan

- [x] 12 new unit tests in `src/common/proxy.rs` (URL parser corner cases, SOCKS5 UDP wrap/unwrap roundtrips, fragment/ATYP rejection paths).
- [x] New `tests/proxy.rs` integration test stands up an in-process SOCKS5 UDP relay and asserts a real Rusnel client + server pair completes the QUIC handshake through it and round-trips bytes over a tunneled TCP echo.
- [x] All existing test suites still pass (`cargo test --all`).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --all -- -D warnings` clean.
- [x] Version bumped to `0.6.0`; CHANGELOG updated.
- [x] README CLI help blocks updated; `--proxy` README TODO bullet checked.

## Notes for downstream embedders

- `ServerConfig` gains `pub allow_socks: bool` (default-deny — set to `true` if you previously relied on reverse-SOCKS without the flag).
- `ClientConfig` gains `pub proxy: Option<ProxyConfig>` (`None` = direct connect, existing behaviour).
- `server_receive_remote_request` gains an `allow_socks: bool` parameter alongside `allow_reverse`. Wire format unchanged.

Made with [Cursor](https://cursor.com)