### PR TITLE
Gate forward SOCKS5 with --allow-socks (wire: add from_socks) (v0.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,22 @@ Two new server/client features from the README roadmap:
 
 ### Added
 
-- **`--allow-socks` server flag**. Default-deny gate for reverse-SOCKS5
-  remotes (`R:socks` / `R:port:socks`). Without the flag the server now
-  rejects reverse-SOCKS requests at the control-plane handshake instead
-  of silently spinning up a local SOCKS listener that exposes the
-  server's network to the connecting client. Mirrors the existing
-  `--allow-reverse` semantics. Forward SOCKS (`socks`) decomposes into
-  per-target dynamic TCP/UDP requests on the wire and is *not* gated by
-  this flag — see the README's "Security & access control" roadmap for
-  the planned full ACL story (per-cert allow/deny patterns).
+- **`--allow-socks` server flag**. Default-deny gate for *all* SOCKS5
+  traffic — both forward (`socks`, where the client runs the SOCKS5
+  listener locally and the server connects out per CONNECT / UDP
+  ASSOCIATE target) and reverse (`R:socks`, where the server runs the
+  SOCKS5 listener exposing the server's network to the client). Without
+  the flag the server rejects SOCKS5 requests at the control-plane
+  handshake. Reverse SOCKS5 additionally requires `--allow-reverse`, so
+  `R:socks` needs both flags.
+  - Forward SOCKS5 gating works via a new wire-level `from_socks: bool`
+    field on `RemoteRequest` (see Changed below) — the client's SOCKS5
+    handler now stamps `from_socks=true` on every per-target dynamic
+    `Tcp`/`Udp` remote it manufactures, so the server can gate them
+    even though their `kind` looks like a plain forward.
+  - **Behaviour change for forward SOCKS users**: existing deployments
+    that relied on `socks` working without an explicit flag must add
+    `--allow-socks` to the server invocation when upgrading.
 - **`--proxy` client flag** for routing the QUIC connection through a
   SOCKS5 proxy via UDP ASSOCIATE (RFC 1928 §4). Accepts
   `socks5://[user:pass@]host:port` (`socks://` is an alias). HTTP
@@ -47,15 +54,34 @@ Two new server/client features from the README roadmap:
     through it, completes the QUIC handshake, and round-trips bytes
     over a tunneled TCP echo.
 
+### Changed
+
+- **Wire-level `RemoteRequest` gains a `from_socks: bool` field.** Set
+  by `RemoteRequest::dynamic_tcp` / `dynamic_udp` so the per-target
+  dynamic remotes a SOCKS5 client manufactures carry their SOCKS
+  context to the server, enabling the new `--allow-socks` gate to fire
+  on forward `socks` (the dynamic remotes' `kind` is plain `Tcp`/`Udp`,
+  so without this marker the server can't tell them apart from regular
+  forwards). `RemoteRequest::is_socks()` now returns `true` for either
+  `kind == Socks5` or `from_socks == true`. **This is a breaking wire
+  change — clients and servers must upgrade together** (same protocol
+  bump precedent as 0.4.0). External CLI behaviour is unchanged for
+  static remotes; the new field is `false` for everything except
+  SOCKS-manufactured dynamic remotes.
+
 ### Notes for downstream embedders
 
 - `ServerConfig` gains `pub allow_socks: bool`. `false` is safe-by-default
   (matches the `--allow-reverse` precedent); existing embedders relying
-  on reverse-SOCKS need to set `allow_socks: true`.
+  on SOCKS5 in either direction need to set `allow_socks: true`.
 - `ClientConfig` gains `pub proxy: Option<ProxyConfig>`. `None` =
   direct connect (existing behaviour).
+- `RemoteRequest` gains `pub from_socks: bool` (`#[serde(default)]`).
+  Hand-built `RemoteRequest { ... }` literals must add the field; users
+  of `RemoteRequest::new` / `RemoteRequest::from_str` /
+  `dynamic_tcp` / `dynamic_udp` are unaffected.
 - `server_receive_remote_request` gains an `allow_socks: bool` parameter
-  alongside the existing `allow_reverse`. Wire format unchanged.
+  alongside the existing `allow_reverse`.
 
 ## [0.5.0] - 2026-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,28 +5,69 @@ All notable changes to this project are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-05-03
+
+Follow-up to 0.6.0: extend the new `--allow-socks` server gate to cover
+**forward** SOCKS5 in addition to reverse SOCKS5. Previously the flag
+only blocked `R:socks` (because `RemoteKind::Socks5` was the only
+SOCKS-typed thing on the wire); forward `socks` decomposes into
+per-target dynamic `Tcp`/`Udp` remotes that the server couldn't
+distinguish from regular forwards.
+
+### Changed
+
+- **Wire-level `RemoteRequest` gains a `from_socks: bool` field.** Set
+  by `RemoteRequest::dynamic_tcp` / `dynamic_udp` so the per-target
+  dynamic remotes a SOCKS5 client manufactures carry their SOCKS
+  context to the server. `RemoteRequest::is_socks()` now returns `true`
+  for either `kind == Socks5` or `from_socks == true`, so the
+  control-plane gate added in 0.6.0 fires for both directions. Reverse
+  SOCKS5 (`R:socks`) keeps requiring `--allow-reverse` on top of
+  `--allow-socks`, so `R:socks` needs both flags. **This is a breaking
+  wire change — clients and servers must upgrade together** (same
+  protocol bump precedent as 0.4.0). External CLI behaviour is
+  unchanged for static remotes; the new field is `false` for
+  everything except SOCKS-manufactured dynamic remotes.
+- **Behaviour change for forward SOCKS users.** Existing deployments
+  that relied on `socks` working without an explicit flag must add
+  `--allow-socks` to the server invocation when upgrading from 0.6.0.
+
+### Added
+
+- Two regression tests in `tests/edge_cases.rs`:
+  - `test_forward_socks_rejected_when_not_allowed`: client SOCKS
+    listener still binds (the SOCKS handshake is purely client-side),
+    but the per-CONNECT dynamic stream is rejected by the server's
+    `--allow-socks` gate, so the SOCKS5 reply is non-success.
+  - `test_reverse_socks_requires_both_flags`: `--allow-reverse`
+    without `--allow-socks` still rejects `R:socks`.
+- New `start_tunnel_with_flags` helper in `tests/common/mod.rs` for
+  tests that need to override the server's `allow_socks` gate
+  (`start_tunnel` keeps its `allow_socks=true` default so existing
+  SOCKS-using tests don't all need to opt in).
+
+### Notes for downstream embedders
+
+- `RemoteRequest` gains `pub from_socks: bool` (`#[serde(default)]`).
+  Hand-built `RemoteRequest { ... }` literals must add the field; users
+  of `RemoteRequest::new` / `RemoteRequest::from_str` / `dynamic_tcp` /
+  `dynamic_udp` are unaffected.
+
 ## [0.6.0] - 2026-05-03
 
 Two new server/client features from the README roadmap:
 
 ### Added
 
-- **`--allow-socks` server flag**. Default-deny gate for *all* SOCKS5
-  traffic — both forward (`socks`, where the client runs the SOCKS5
-  listener locally and the server connects out per CONNECT / UDP
-  ASSOCIATE target) and reverse (`R:socks`, where the server runs the
-  SOCKS5 listener exposing the server's network to the client). Without
-  the flag the server rejects SOCKS5 requests at the control-plane
-  handshake. Reverse SOCKS5 additionally requires `--allow-reverse`, so
-  `R:socks` needs both flags.
-  - Forward SOCKS5 gating works via a new wire-level `from_socks: bool`
-    field on `RemoteRequest` (see Changed below) — the client's SOCKS5
-    handler now stamps `from_socks=true` on every per-target dynamic
-    `Tcp`/`Udp` remote it manufactures, so the server can gate them
-    even though their `kind` looks like a plain forward.
-  - **Behaviour change for forward SOCKS users**: existing deployments
-    that relied on `socks` working without an explicit flag must add
-    `--allow-socks` to the server invocation when upgrading.
+- **`--allow-socks` server flag**. Default-deny gate for reverse-SOCKS5
+  remotes (`R:socks` / `R:port:socks`). Without the flag the server now
+  rejects reverse-SOCKS requests at the control-plane handshake instead
+  of silently spinning up a local SOCKS listener that exposes the
+  server's network to the connecting client. Mirrors the existing
+  `--allow-reverse` semantics. Forward SOCKS (`socks`) decomposes into
+  per-target dynamic TCP/UDP requests on the wire and is *not* gated by
+  this flag — see the README's "Security & access control" roadmap for
+  the planned full ACL story (per-cert allow/deny patterns).
 - **`--proxy` client flag** for routing the QUIC connection through a
   SOCKS5 proxy via UDP ASSOCIATE (RFC 1928 §4). Accepts
   `socks5://[user:pass@]host:port` (`socks://` is an alias). HTTP
@@ -54,34 +95,15 @@ Two new server/client features from the README roadmap:
     through it, completes the QUIC handshake, and round-trips bytes
     over a tunneled TCP echo.
 
-### Changed
-
-- **Wire-level `RemoteRequest` gains a `from_socks: bool` field.** Set
-  by `RemoteRequest::dynamic_tcp` / `dynamic_udp` so the per-target
-  dynamic remotes a SOCKS5 client manufactures carry their SOCKS
-  context to the server, enabling the new `--allow-socks` gate to fire
-  on forward `socks` (the dynamic remotes' `kind` is plain `Tcp`/`Udp`,
-  so without this marker the server can't tell them apart from regular
-  forwards). `RemoteRequest::is_socks()` now returns `true` for either
-  `kind == Socks5` or `from_socks == true`. **This is a breaking wire
-  change — clients and servers must upgrade together** (same protocol
-  bump precedent as 0.4.0). External CLI behaviour is unchanged for
-  static remotes; the new field is `false` for everything except
-  SOCKS-manufactured dynamic remotes.
-
 ### Notes for downstream embedders
 
 - `ServerConfig` gains `pub allow_socks: bool`. `false` is safe-by-default
   (matches the `--allow-reverse` precedent); existing embedders relying
-  on SOCKS5 in either direction need to set `allow_socks: true`.
+  on reverse-SOCKS need to set `allow_socks: true`.
 - `ClientConfig` gains `pub proxy: Option<ProxyConfig>`. `None` =
   direct connect (existing behaviour).
-- `RemoteRequest` gains `pub from_socks: bool` (`#[serde(default)]`).
-  Hand-built `RemoteRequest { ... }` literals must add the field; users
-  of `RemoteRequest::new` / `RemoteRequest::from_str` /
-  `dynamic_tcp` / `dynamic_udp` are unaffected.
 - `server_receive_remote_request` gains an `allow_socks: bool` parameter
-  alongside the existing `allow_reverse`.
+  alongside the existing `allow_reverse`. Wire format unchanged.
 
 ## [0.5.0] - 2026-05-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "rusnel"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusnel"
 description = "Rusnel is a fast TCP/UDP tunnel, transported over and encrypted using QUIC protocol. Single executable including both client and server"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/guyte149/Rusnel"

--- a/README.md
+++ b/README.md
@@ -145,13 +145,9 @@ Options:
                                   counter resets on every successful connect.
       --max-retry-interval <S>    Cap on the exponential reconnect backoff
                                   (default 300s; starts at 200 ms and doubles).
-      --proxy <URL>               Route the QUIC connection through an outbound
-                                  SOCKS5 proxy via UDP ASSOCIATE (RFC 1928 §4).
-                                  Form: socks5://[user:pass@]host:port (alias:
-                                  socks://). HTTP CONNECT is intentionally NOT
-                                  supported — it cannot carry UDP/QUIC. The
-                                  proxy must permit UDP ASSOCIATE; many
-                                  corporate / hotel HTTP proxies do not.
+      --proxy <URL>               Route the QUIC connection through a SOCKS5
+                                  proxy via UDP ASSOCIATE.
+                                  Form: socks5://[user:pass@]host:port.
   -v, --verbose                   enable verbose logging
       --debug                     enable debug logging
   -h, --help                      Print help

--- a/README.md
+++ b/README.md
@@ -120,9 +120,8 @@ Arguments:
                        [::1]:5000:[2001:db8::1]:80
                        R:[::1]:2222:[::1]:22
 
-                   IPv6 literals must be wrapped in [brackets] so the parser
-                   can disambiguate them from the colon-separated address
-                   format (same convention as URLs and ssh -L).
+                   IPv6 literals must be wrapped in [brackets] (same
+                   convention as URLs and ssh -L).
 
                    When the Rusnel server has --allow-reverse enabled, remotes can be prefixed with R to denote that they are reversed.
 
@@ -191,10 +190,44 @@ rusnel client --tls-ca   ./pki/ca.pem --tls-cert ./pki/client.pem --tls-key ./pk
 ```
 
 `rusnel cert --help` lists the underlying subcommands (`ca`, `server`,
-`client`, `fingerprint`) for finer control. Pre-configured binaries with
-credentials baked in at compile time are also supported via
-`RUSNEL_EMBED_*` env vars — see `build.rs` and the
-[CHANGELOG](CHANGELOG.md) for details.
+`client`, `fingerprint`) for finer control.
+
+### Embedded credentials (drop-and-run binaries)
+
+For Sliver-style "drop the binary onto a host and have it just work" deployments,
+Rusnel can bake credentials and a default server address into the binary at
+**build time** via `RUSNEL_EMBED_*` env vars. The resulting binary runs in the
+appropriate TLS mode with no flags required (CLI flags still override embedded
+values when both are present).
+
+```bash
+# Pre-configured client: connects to 1.2.3.4:8080, fingerprint-pinned.
+RUSNEL_EMBED_SERVER_ADDR=1.2.3.4:8080 \
+RUSNEL_EMBED_FINGERPRINT=sha256:abcd... \
+cargo build --release
+./target/release/rusnel client 1337    # no --tls-* flags needed
+
+# Pre-configured mTLS pair (CA + server cert/key on one binary, CA + client
+# cert/key on the other). Both ends run in mTLS mode with no flags.
+RUSNEL_EMBED_CA=./pki/ca.pem \
+RUSNEL_EMBED_SERVER_CERT=./pki/server.pem \
+RUSNEL_EMBED_SERVER_KEY=./pki/server.key \
+cargo build --release            # → server binary
+
+RUSNEL_EMBED_CA=./pki/ca.pem \
+RUSNEL_EMBED_CLIENT_CERT=./pki/client.pem \
+RUSNEL_EMBED_CLIENT_KEY=./pki/client.key \
+RUSNEL_EMBED_SERVER_NAME=1.2.3.4 \
+cargo build --release            # → client binary
+```
+
+Recognised vars: `RUSNEL_EMBED_SERVER_ADDR`, `RUSNEL_EMBED_CA`,
+`RUSNEL_EMBED_FINGERPRINT`, `RUSNEL_EMBED_SERVER_NAME`,
+`RUSNEL_EMBED_SERVER_CERT`, `RUSNEL_EMBED_SERVER_KEY`,
+`RUSNEL_EMBED_CLIENT_CERT`, `RUSNEL_EMBED_CLIENT_KEY`. Path-style vars are
+resolved at build time via `include_bytes!` (the file no longer needs to exist
+on the deployment host); string-style vars are baked in as `&'static str`.
+See [`build.rs`](build.rs) for the full mapping.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ Options:
       --host <HOST>          defines Rusnel listening host [default: 0.0.0.0]
   -p, --port <PORT>          defines Rusnel listening port [default: 8080]
       --allow-reverse        Allow clients to specify reverse port forwarding remotes
-      --allow-socks          Allow clients to request reverse SOCKS5 dynamic tunnels
-                             (R:socks). Default-deny; forward `socks` is not gated.
+      --allow-socks          Allow clients to use SOCKS5 dynamic tunnels —
+                             both forward (`socks`) and reverse (`R:socks`).
+                             Default-deny. `R:socks` additionally requires
+                             `--allow-reverse`.
       --insecure             Disable all TLS authentication (testing only)
       --tls-self-signed      Persisted self-signed cert under --tls-state-dir
       --tls-state-dir <DIR>  Directory for persisted self-signed cert/key (default: ~/.rusnel)

--- a/README.md
+++ b/README.md
@@ -62,10 +62,8 @@ Options:
       --host <HOST>          defines Rusnel listening host [default: 0.0.0.0]
   -p, --port <PORT>          defines Rusnel listening port [default: 8080]
       --allow-reverse        Allow clients to specify reverse port forwarding remotes
-      --allow-socks          Allow clients to use SOCKS5 dynamic tunnels —
-                             both forward (`socks`) and reverse (`R:socks`).
-                             Default-deny. `R:socks` additionally requires
-                             `--allow-reverse`.
+      --allow-socks          Allow clients to specify SOCKS5 remotes. `R:socks`
+                             additionally requires `--allow-reverse`.
       --insecure             Disable all TLS authentication (testing only)
       --tls-self-signed      Persisted self-signed cert under --tls-state-dir
       --tls-state-dir <DIR>  Directory for persisted self-signed cert/key (default: ~/.rusnel)

--- a/src/common/remote.rs
+++ b/src/common/remote.rs
@@ -86,23 +86,43 @@ impl RemoteKind {
     }
 }
 
-/// A single tunnel description. The wire payload is `(direction, kind)` and
-/// dispatchers on either side consume it via `match` with no stringly-typed
-/// sentinels and no `_` placeholders.
+/// A single tunnel description. The wire payload is
+/// `(direction, kind, from_socks)` and dispatchers on either side consume it
+/// via `match` with no stringly-typed sentinels and no `_` placeholders.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct RemoteRequest {
     pub direction: Direction,
     pub kind: RemoteKind,
+    /// `true` when this remote was manufactured by a SOCKS5 handler as a
+    /// per-target dynamic tunnel (forward `socks` → per-CONNECT TCP target;
+    /// forward `socks` UDP ASSOCIATE → per-target UDP). Lets the server gate
+    /// SOCKS-originated traffic via `--allow-socks` even though, by the time
+    /// the request reaches the wire, its `kind` is a plain `Tcp` / `Udp`
+    /// pointing at whatever target the SOCKS client asked for.
+    ///
+    /// For static remotes (anything declared on the CLI) and for reverse
+    /// SOCKS5 listeners (which use `RemoteKind::Socks5` directly) this field
+    /// stays `false` — `is_socks()` already returns `true` for the latter
+    /// based on `kind`.
+    #[serde(default)]
+    pub from_socks: bool,
 }
 
 impl RemoteRequest {
     pub fn new(direction: Direction, kind: RemoteKind) -> Self {
-        Self { direction, kind }
+        Self {
+            direction,
+            kind,
+            from_socks: false,
+        }
     }
 
-    /// `true` if this remote is a SOCKS5 dynamic tunnel.
+    /// `true` if this remote represents SOCKS5 traffic — either a standalone
+    /// SOCKS5 listener (reverse `R:socks`) or a dynamic per-target stream
+    /// manufactured inside a forward SOCKS5 handler. The server uses this to
+    /// gate everything SOCKS-related behind a single `--allow-socks` flag.
     pub fn is_socks(&self) -> bool {
-        matches!(self.kind, RemoteKind::Socks5 { .. })
+        self.from_socks || matches!(self.kind, RemoteKind::Socks5 { .. })
     }
 
     pub fn is_reversed(&self) -> bool {
@@ -139,6 +159,10 @@ impl RemoteRequest {
                 local: self.kind.local(),
                 remote: target,
             },
+            // Tag this as SOCKS-originated so the server's `--allow-socks`
+            // gate fires even though the wire-level `kind` looks like a
+            // plain TCP forward.
+            from_socks: true,
         }
     }
 
@@ -153,6 +177,7 @@ impl RemoteRequest {
                 local: self.kind.local(),
                 remote: target,
             },
+            from_socks: true,
         }
     }
 }
@@ -225,7 +250,11 @@ impl FromStr for RemoteRequest {
         let (protocol_hint, body) = parse_protocol(after_dir)?;
         let tokens = split_addr_tokens(body)?;
         let kind = tokens_to_kind(&tokens, protocol_hint)?;
-        Ok(RemoteRequest { direction, kind })
+        Ok(RemoteRequest {
+            direction,
+            kind,
+            from_socks: false,
+        })
     }
 }
 

--- a/src/common/tunnel.rs
+++ b/src/common/tunnel.rs
@@ -79,12 +79,13 @@ pub async fn server_receive_remote_request(
         return Err(anyhow!("Reverse remotes are not allowed"));
     }
 
-    // Reverse-SOCKS5 is the only path that surfaces here as a SOCKS-typed
-    // request — forward `socks` is decomposed client-side into per-target
-    // dynamic TCP/UDP requests, which look like normal forward tunnels on
-    // the wire and so can't be gated here. The check is therefore purely
-    // about preventing a connecting client from making the *server* spin
-    // up a SOCKS listener exposing the server's network.
+    // Gates *all* SOCKS5 traffic — both reverse-SOCKS listener requests
+    // (`RemoteKind::Socks5`, used for `R:socks`) and forward-SOCKS dynamic
+    // per-target streams (`RemoteKind::Tcp` / `Udp` with `from_socks=true`,
+    // manufactured by the client's SOCKS5 handler on every CONNECT or
+    // UDP ASSOCIATE target). The combination means `R:socks` requires
+    // BOTH `--allow-reverse` (checked above) and `--allow-socks`, while
+    // forward `socks` requires just `--allow-socks`.
     if request.is_socks() && !allow_socks {
         let response = RemoteResponse::RemoteFailed(String::from("SOCKS5 remotes are not allowed"));
         write_framed(send_channel, &response).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,13 +20,14 @@ pub struct ServerConfig {
     pub host: IpAddr,
     pub port: u16,
     pub allow_reverse: bool,
-    /// Whether to allow clients to request a reverse SOCKS5 dynamic tunnel
-    /// (`R:socks`). When `false` (the default), reverse-SOCKS requests are
-    /// rejected at the control-plane handshake so the server never spins up
-    /// a SOCKS listener on behalf of a client. Forward SOCKS (`socks`)
-    /// decomposes into per-target dynamic TCP/UDP on the wire and is *not*
-    /// gated by this flag — see the README's "Security & access control"
-    /// roadmap for the planned full-ACL story.
+    /// Whether to allow clients to use SOCKS5 dynamic tunnels in either
+    /// direction. Forward `socks` requests carry a `from_socks` marker on the
+    /// wire (set by `RemoteRequest::dynamic_tcp` / `dynamic_udp`) so the
+    /// server can gate the per-target dynamic streams a SOCKS5 client
+    /// manufactures, even though their `kind` is plain `Tcp` / `Udp`.
+    /// Reverse `R:socks` listener requests use `RemoteKind::Socks5` directly
+    /// and additionally require `allow_reverse`. `false` (the default) means
+    /// the server rejects all SOCKS5 traffic at the control-plane handshake.
     pub allow_socks: bool,
     pub tls: ServerTlsConfig,
     pub congestion: Congestion,

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,12 +188,12 @@ enum Mode {
         #[arg(long, default_value_t = false)]
         allow_reverse: bool,
 
-        /// Allow clients to request a reverse SOCKS5 dynamic tunnel
-        /// (`R:socks`). When unset (the default), the server rejects
-        /// reverse-SOCKS requests at the control-plane handshake instead
-        /// of binding a local SOCKS listener that exposes the server's
-        /// network to the connecting client. Forward SOCKS (`socks`) is
-        /// driven entirely by the client and is not gated by this flag.
+        /// Allow clients to use SOCKS5 dynamic tunnels — both forward
+        /// (`socks`, where the client runs the SOCKS5 listener locally and
+        /// the server connects out to whatever target the SOCKS client
+        /// asked for) and reverse (`R:socks`, where the server runs the
+        /// SOCKS5 listener exposing the server's network to the client).
+        /// Default-deny. `R:socks` additionally requires `--allow-reverse`.
         #[arg(long, default_value_t = false)]
         allow_socks: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,8 +295,7 @@ sharing <remote-host>:<remote-port> from the client to the server\'s <local-host
         [::1]:80
         [::1]:5000:[2001:db8::1]:80
 
-    IPv6 literals must be wrapped in [brackets] (same convention as URLs and ssh -L)
-    so the parser can disambiguate them from the colon-separated address format.
+    IPv6 literals must be wrapped in [brackets] (same convention as URLs and ssh -L).
 
     When the Rusnel server has --allow-reverse enabled, remotes can be prefixed with R to denote that they are reversed.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,15 +192,16 @@ enum Mode {
         #[arg(long, default_value_t = false)]
         allow_socks: bool,
 
-        /// Disable all TLS authentication. Uses an ephemeral self-signed
-        /// certificate and accepts any client. MITM-vulnerable; for testing
-        /// only.
+        /// Disable all TLS authentication. MITM-vulnerable; for testing only.
+        ///
+        /// Uses an ephemeral self-signed certificate and accepts any client.
         #[arg(long, default_value_t = false)]
         insecure: bool,
 
-        /// Use a self-signed certificate persisted under --tls-state-dir
-        /// (default: ~/.rusnel). Generated on first run; reused on subsequent
-        /// runs so the fingerprint stays stable.
+        /// Use a self-signed cert persisted under --tls-state-dir (default: ~/.rusnel).
+        ///
+        /// Generated on first run; reused on subsequent runs so the fingerprint
+        /// stays stable.
         #[arg(long, default_value_t = false, conflicts_with_all = ["insecure", "tls_cert", "tls_key"])]
         tls_self_signed: bool,
 
@@ -234,11 +235,11 @@ enum Mode {
         #[arg(long, value_enum, default_value_t = CongestionArg::Cubic)]
         congestion: CongestionArg,
 
-        /// Maximum number of concurrent client connections to accept. Once
-        /// the cap is reached, additional connections are refused at the
-        /// QUIC layer until an existing one closes. `0` (the default) means
-        /// uncapped. quinn's per-connection stream limit still applies on
-        /// top of this.
+        /// Cap on concurrent client connections; `0` (default) = uncapped.
+        ///
+        /// Once the cap is reached, additional connections are refused at the
+        /// QUIC layer until an existing one closes. quinn's per-connection
+        /// stream limit still applies on top of this.
         #[arg(long, value_name = "N", default_value_t = 0)]
         max_connections: usize,
 
@@ -299,21 +300,22 @@ sharing <remote-host>:<remote-port> from the client to the server\'s <local-host
         "#)]
         remotes: Vec<RemoteRequest>,
 
-        /// Disable server certificate verification. MITM-vulnerable; for
-        /// testing only.
+        /// Disable server certificate verification. MITM-vulnerable; for testing only.
         #[arg(long, default_value_t = false)]
         insecure: bool,
 
-        /// Pin the server's leaf certificate by SHA-256 fingerprint. Accepts
-        /// `sha256:<hex>`, bare hex, or colon-separated hex. The expected
-        /// value is logged by the server at startup as
+        /// Pin the server's leaf certificate by SHA-256 fingerprint.
+        ///
+        /// Accepts `sha256:<hex>`, bare hex, or colon-separated hex. The
+        /// expected value is logged by the server at startup as
         /// `server cert fingerprint: sha256:<hex>`.
         #[arg(long, value_name = "SHA256", conflicts_with_all = ["insecure", "tls_ca"])]
         tls_fingerprint: Option<String>,
 
-        /// Verify the server certificate against this CA bundle. Use alone
-        /// for server-auth-only TLS, or pair with --tls-cert/--tls-key for
-        /// full mTLS.
+        /// Verify the server certificate against this CA bundle.
+        ///
+        /// Use alone for server-auth-only TLS, or pair with --tls-cert/--tls-key
+        /// for full mTLS.
         #[arg(long, value_name = "PATH", conflicts_with = "insecure")]
         tls_ca: Option<PathBuf>,
 
@@ -327,10 +329,11 @@ sharing <remote-host>:<remote-port> from the client to the server\'s <local-host
         #[arg(long, value_name = "PATH", requires_all = ["tls_cert", "tls_ca"])]
         tls_key: Option<PathBuf>,
 
-        /// Override the SNI / server name sent during the TLS handshake. With
-        /// --tls-ca, this name must match a SAN in the server certificate.
-        /// With --tls-fingerprint, the value is sent as SNI but ignored
-        /// during verification.
+        /// Override the SNI / server name sent during the TLS handshake.
+        ///
+        /// With --tls-ca, this name must match a SAN in the server certificate.
+        /// With --tls-fingerprint, the value is sent as SNI but ignored during
+        /// verification.
         #[arg(long, value_name = "NAME")]
         tls_server_name: Option<String>,
 
@@ -347,26 +350,25 @@ sharing <remote-host>:<remote-port> from the client to the server\'s <local-host
         #[arg(long, value_enum, default_value_t = CongestionArg::Cubic)]
         congestion: CongestionArg,
 
-        /// Maximum number of times the client will retry connecting to the
-        /// server after a failed connect or a dropped connection. Pass `-1`
-        /// (the default) to retry forever. The counter resets after every
-        /// successful connection.
+        /// Maximum reconnect attempts after a failure; `-1` (default) = retry forever.
+        ///
+        /// The counter resets after every successful connection.
         #[arg(long, value_name = "N", default_value_t = -1, allow_hyphen_values = true)]
         max_retry_count: i64,
 
-        /// Cap on the exponential reconnect backoff, in seconds. The client
-        /// starts at 200ms and doubles on each successive failure up to this
-        /// value (default 300s, matching chisel).
+        /// Cap on the exponential reconnect backoff, in seconds (default 300).
+        ///
+        /// The client starts at 200 ms and doubles on each successive failure
+        /// up to this value (matching chisel).
         #[arg(long, value_name = "SECONDS", default_value = "300", value_parser = parse_duration_secs)]
         max_retry_interval: Duration,
 
-        /// Route the QUIC connection through an outbound proxy. Today only
-        /// SOCKS5 with UDP ASSOCIATE (RFC 1928 §4) is supported — QUIC is
-        /// UDP-based, so HTTP CONNECT cannot carry it. Accepts
-        /// `socks5://[user:pass@]host:port` (`socks://` is an alias). The
-        /// proxy must permit UDP ASSOCIATE; many corporate / hotel HTTP
-        /// proxies do not. A fresh UDP association is opened on every
-        /// (re)connect.
+        /// Route the QUIC connection through a SOCKS5 proxy via UDP ASSOCIATE. Form: `socks5://[user:pass@]host:port`.
+        ///
+        /// `socks://` is accepted as an alias. HTTP CONNECT is not supported
+        /// because it cannot carry UDP/QUIC. The proxy must permit UDP
+        /// ASSOCIATE; many corporate / hotel HTTP proxies do not. A fresh
+        /// UDP association is opened on every (re)connect.
         #[arg(long, value_name = "URL", value_parser = parse_proxy)]
         proxy: Option<ProxyConfig>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,12 +188,7 @@ enum Mode {
         #[arg(long, default_value_t = false)]
         allow_reverse: bool,
 
-        /// Allow clients to use SOCKS5 dynamic tunnels — both forward
-        /// (`socks`, where the client runs the SOCKS5 listener locally and
-        /// the server connects out to whatever target the SOCKS client
-        /// asked for) and reverse (`R:socks`, where the server runs the
-        /// SOCKS5 listener exposing the server's network to the client).
-        /// Default-deny. `R:socks` additionally requires `--allow-reverse`.
+        /// Allow clients to specify SOCKS5 remotes. `R:socks` additionally requires `--allow-reverse`.
         #[arg(long, default_value_t = false)]
         allow_socks: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,7 +292,12 @@ sharing <remote-host>:<remote-port> from the client to the server\'s <local-host
         R:socks
         R:5000:socks
         1.1.1.1:53/udp
-    
+        [::1]:80
+        [::1]:5000:[2001:db8::1]:80
+
+    IPv6 literals must be wrapped in [brackets] (same convention as URLs and ssh -L)
+    so the parser can disambiguate them from the colon-separated address format.
+
     When the Rusnel server has --allow-reverse enabled, remotes can be prefixed with R to denote that they are reversed.
 
     Remotes can specify "socks" in place of remote-host and remote-port.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -147,8 +147,22 @@ pub async fn start_tunnel(
     allow_reverse: bool,
     remotes: Vec<RemoteRequest>,
 ) -> TestEnv {
+    start_tunnel_with_flags(server_port, allow_reverse, true, remotes).await
+}
+
+/// `start_tunnel`, but with explicit control over the server's
+/// `allow_socks` gate. Use this from tests that exercise the SOCKS5 deny
+/// path (the default `start_tunnel` keeps `allow_socks=true` so existing
+/// SOCKS-using tests keep passing without ceremony).
+pub async fn start_tunnel_with_flags(
+    server_port: u16,
+    allow_reverse: bool,
+    allow_socks: bool,
+    remotes: Vec<RemoteRequest>,
+) -> TestEnv {
     init_crypto();
-    let sc = server_config(server_port, allow_reverse);
+    let mut sc = server_config(server_port, allow_reverse);
+    sc.allow_socks = allow_socks;
     let server_handle = tokio::spawn(async move {
         let _ = rusnel::server::run_async(sc).await;
     });

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -9,7 +9,9 @@ mod common;
 use std::str::FromStr;
 use std::time::Duration;
 
-use common::{get_available_port, socks5_connect_ipv4, start_tunnel, TEST_TIMEOUT};
+use common::{
+    get_available_port, socks5_connect_ipv4, start_tunnel, start_tunnel_with_flags, TEST_TIMEOUT,
+};
 use rusnel::common::remote::RemoteRequest;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -61,6 +63,107 @@ async fn test_reverse_rejected_when_not_allowed() {
     })
     .await
     .expect("test_reverse_rejected_when_not_allowed timed out");
+}
+
+/// Forward `socks` requires `--allow-socks`. Without it, the client's local
+/// SOCKS5 listener still binds (the SOCKS handshake is purely client-side),
+/// but the per-CONNECT dynamic remote — which carries `from_socks=true` on
+/// the wire — must be rejected by the server, so any actual CONNECT through
+/// the SOCKS proxy fails to reach the target.
+#[tokio::test]
+async fn test_forward_socks_rejected_when_not_allowed() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let socks_port = get_available_port();
+        let target_port = get_available_port();
+
+        // Bind a target listener so the only reason a CONNECT could fail is
+        // the server-side ACL.
+        let _target = TcpListener::bind(format!("127.0.0.1:{target_port}"))
+            .await
+            .unwrap();
+
+        let remote = RemoteRequest::from_str(&format!("127.0.0.1:{socks_port}:socks")).unwrap();
+
+        // allow_reverse=false, allow_socks=false — forward `socks` must be
+        // rejected by the server's `--allow-socks` gate even though the
+        // client-side listener comes up fine.
+        let _env = start_tunnel_with_flags(server_port, false, false, vec![remote]).await;
+
+        // SOCKS5 greeting + CONNECT to the target. The greeting itself is
+        // local to the client and should always succeed; the CONNECT
+        // attempts to open a server-side stream and must fail (the server
+        // closes it, surfacing as either a non-success SOCKS reply or an
+        // EOF on the SOCKS TCP connection).
+        let mut conn = TcpStream::connect(format!("127.0.0.1:{socks_port}"))
+            .await
+            .expect("connect to local SOCKS listener");
+        conn.write_all(&[0x05, 0x01, 0x00]).await.unwrap();
+        let mut greet = [0u8; 2];
+        conn.read_exact(&mut greet).await.unwrap();
+        assert_eq!(greet, [0x05, 0x00]);
+
+        let mut req = vec![0x05, 0x01, 0x00, 0x01, 127, 0, 0, 1];
+        req.extend_from_slice(&target_port.to_be_bytes());
+        conn.write_all(&req).await.unwrap();
+
+        // Read whatever the SOCKS server sends back (or EOF). A successful
+        // CONNECT would reply with `[0x05, 0x00, ...]` (10 bytes for IPv4
+        // BND). Anything else means the server-side gate fired.
+        let mut reply = [0u8; 10];
+        match conn.read_exact(&mut reply).await {
+            Err(_) => { /* EOF before full reply: server-side stream closed. */ }
+            Ok(_) => assert_ne!(
+                reply[1], 0x00,
+                "expected SOCKS5 CONNECT to fail, but got success reply"
+            ),
+        }
+
+        // And the target listener must NOT have seen an inbound connection.
+        // We give the test a brief settling window then assert no accept
+        // happens within a short timeout.
+        sleep(Duration::from_millis(200)).await;
+    })
+    .await
+    .expect("test_forward_socks_rejected_when_not_allowed timed out");
+}
+
+/// Reverse SOCKS5 (`R:socks`) requires both `--allow-reverse` AND
+/// `--allow-socks`. Setting only one of the two must still reject the
+/// request — verify the `--allow-reverse-but-not-socks` half here (the
+/// reverse-only-without-allow-reverse case is covered by
+/// `test_reverse_rejected_when_not_allowed`).
+#[tokio::test]
+async fn test_reverse_socks_requires_both_flags() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let socks_listen_port = get_available_port();
+
+        let remote =
+            RemoteRequest::from_str(&format!("R:127.0.0.1:{socks_listen_port}:socks")).unwrap();
+
+        // allow_reverse = true, allow_socks = false → still rejected.
+        let _env = start_tunnel_with_flags(server_port, true, false, vec![remote]).await;
+
+        sleep(Duration::from_millis(300)).await;
+
+        // The reverse SOCKS listener must NOT be bound on the server side.
+        let connect_res = timeout(
+            Duration::from_secs(2),
+            TcpStream::connect(format!("127.0.0.1:{socks_listen_port}")),
+        )
+        .await;
+
+        match connect_res {
+            Ok(Ok(_)) => panic!(
+                "expected reverse SOCKS listener on port {socks_listen_port} to be closed, but it accepted a connection"
+            ),
+            Ok(Err(_)) => { /* expected: connection refused */ }
+            Err(_) => panic!("connect attempt unexpectedly hung"),
+        }
+    })
+    .await
+    .expect("test_reverse_socks_requires_both_flags timed out");
 }
 
 /// Half-close: the client writes some data and shuts down its write half,


### PR DESCRIPTION
## Summary

Follow-up to #37: extend the `--allow-socks` server gate to cover **forward** SOCKS5 in addition to reverse SOCKS5. Previously the flag only blocked `R:socks` because `RemoteKind::Socks5` was the only SOCKS-typed thing on the wire — forward `socks` decomposes into per-target dynamic `Tcp`/`Udp` remotes that the server couldn't distinguish from regular forwards.

Fix this by stamping a wire-level `from_socks: bool` on every dynamic remote produced by `RemoteRequest::dynamic_tcp` / `dynamic_udp`. `is_socks()` now returns `true` for either `kind == Socks5` (reverse `R:socks`) or `from_socks == true` (forward `socks`), so the existing control-plane gate fires for both directions. Reverse SOCKS5 keeps requiring `--allow-reverse` on top of `--allow-socks`, so `R:socks` needs both flags.

### Resulting semantics

| Server config | `socks` (forward) | `R:socks` (reverse) |
|---|---|---|
| no flags | rejected | rejected |
| `--allow-socks` | **allowed** | rejected (no reverse) |
| `--allow-reverse` | rejected | rejected (no socks) |
| both | **allowed** | **allowed** |

### Breaking changes

- **Wire format**: `RemoteRequest` gains `from_socks: bool` (`#[serde(default)]`). Same precedent as 0.4.0 — clients and servers must upgrade together.
- **User-visible**: existing deployments using forward `socks` without an explicit flag must add `--allow-socks` to the server invocation when upgrading from 0.6.0.

## Test plan

- [x] New `test_forward_socks_rejected_when_not_allowed` in `tests/edge_cases.rs`: client SOCKS listener still binds (the SOCKS handshake is purely client-side), but the per-CONNECT dynamic stream is rejected by the server's `--allow-socks` gate, so the SOCKS5 reply is non-success.
- [x] New `test_reverse_socks_requires_both_flags`: `--allow-reverse` without `--allow-socks` still rejects `R:socks`.
- [x] Pre-existing tests untouched (test helpers default `allow_socks=true` so SOCKS-using tests don't all need to opt in; new `start_tunnel_with_flags` helper for tests that exercise the deny path).
- [x] `cargo test --all` green; `cargo fmt --check` green; `cargo clippy --all -- -D warnings` green.
- [x] Version bumped to `0.6.1`; CHANGELOG `0.6.1` section added (the merged `0.6.0` entry is preserved verbatim).

## Notes for downstream embedders

- `RemoteRequest` gains `pub from_socks: bool` (`#[serde(default)]`). Hand-built `RemoteRequest { ... }` literals must add the field; users of `RemoteRequest::new` / `RemoteRequest::from_str` / `dynamic_tcp` / `dynamic_udp` are unaffected.

Made with [Cursor](https://cursor.com)