### PR TITLE
Server admin API + ctl, then session-hello wire refactor (v0.7.0 + v0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,86 @@ All notable changes to this project are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-05-03
+
+Phase-1 of the long-tracked **server admin API + CLI** README item: the
+server can now expose a read-only HTTP API over a unix domain socket so
+operators can list active clients, the tunnels each client declared,
+the live conns going through every tunnel, and per-tunnel / per-conn
+byte counters. A new `rusnel ctl` subcommand wraps the API for the
+shell.
+
+Write endpoints (kick client, kill conn), Prometheus `/metrics`, and
+the embedded web UI are explicit phase-2 follow-ups.
+
+### Added
+
+- **Three-layer client / tunnel / conn data model.** A *client* is one
+  connected client daemon (`rusnel client`) talking to this server; a
+  *tunnel* is the remote declaration that client established with the
+  server (deduplicated per client by spec, lives for the client's
+  lifetime); a *conn* is a single proxied network connection going
+  through a tunnel (one accepted local TCP socket, one per-source UDP
+  flow, one SOCKS5 CONNECT, one SOCKS5 UDP target). Tunnels expose
+  cumulative byte counters across every conn that ever ran through
+  them; conns expose live counters for their own bytes plus an
+  optional human-readable `peer` label.
+- **Read-only admin HTTP API enabled by default** at
+  `~/.rusnel/admin.sock` (parent directory auto-created, socket created
+  with mode `0600`). Serves
+  `GET /api/v1/{server,clients,clients/:id,clients/:id/{tunnels,conns},tunnels,tunnels/:id,tunnels/:id/conns,conns,conns/:id,history}`.
+  Filesystem permissions are the only auth: access to the socket
+  implies full read access to live client/tunnel/conn metadata.
+  Override with `--admin-socket <path>` (e.g. when running multiple
+  servers as the same uid); disable entirely with `--no-admin-socket`.
+- **`rusnel ctl` subcommand** — read-only client for the admin API.
+  Subcommands: `server`, `clients`, `client <id>`, `client-conns <id>`,
+  `tunnels`, `tunnel <id>`, `tunnel-conns <id>`, `conns`, `history`.
+  Output defaults to a tab-aligned table; `--json` passes the raw API
+  payload through. Defaults to the same `~/.rusnel/admin.sock` path
+  the server uses, so the zero-flag pairing just works; override with
+  `--socket <path>`.
+- **Per-tunnel byte counters** on the data plane. TCP-style copies
+  account via a new `CountedReader` wrapper around the existing
+  `BufReader` chain in `src/common/tcp.rs`; datagram paths
+  (`src/common/udp.rs`, `src/common/socks.rs`) bump the counters
+  directly with each datagram length. The `bytes_in` field counts data
+  received from the QUIC peer; `bytes_out` counts data sent to it. Both
+  use `Ordering::Relaxed` — the admin API is observability, not a sync
+  primitive.
+- **Bounded connection-history ring buffer** (256 entries, oldest
+  evicted). Each `HistoryEntry` carries the disconnect reason already
+  shown in the existing `client disconnected: ...` info log, so
+  operators can correlate.
+- **`tests/admin.rs`** end-to-end test: brings up server + client on
+  localhost, asserts socket mode is `0600`, exercises every read
+  endpoint, pushes bytes through a forward TCP tunnel, and confirms
+  per-tunnel `bytes_in` / `bytes_out` advance.
+- **`src/common/counted.rs`** — `TunnelCounters` (two `Arc<AtomicU64>`s
+  shareable between the admin API and the data plane) and
+  `CountedReader<R: AsyncRead>`. Unit-tested in-module.
+
+### Changed
+
+- **`ServerConfig` gains an `admin_socket: Option<PathBuf>` field.**
+  Library embedders must add it; existing CLI users only see the new
+  flag.
+- **Tunnel handler signatures take a new `Counters = Option<Arc<TunnelCounters>>`
+  argument.** The server passes `Some` for tunnels it has registered;
+  the client side always passes `None`. Affects
+  `tunnel_tcp_stream`, `tunnel_tcp_client`, `tunnel_tcp_server`,
+  `tunnel_udp_stream`, `tunnel_udp_client`, `tunnel_udp_server`, and
+  `tunnel_socks_client`.
+
+### Dependencies
+
+- Added: `axum 0.7` (json, tokio, http1, matched-path, query;
+  `default-features = false`), `hyper 1` (client + server, http1),
+  `hyper-util 0.1` (tokio + service), `http-body-util 0.1`, `tower 0.5`
+  (util only), `serde_json 1`. Total transitive footprint is small —
+  the existing `quinn` + `tokio` + `rustls` graph already pulls in most
+  of the supporting crates.
+
 ## [0.6.1] - 2026-05-03
 
 Follow-up to 0.6.0: extend the new `--allow-socks` server gate to cover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,73 @@ All notable changes to this project are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-05-03
+
+Wire-protocol overhaul. The per-stream `RemoteRequest` handshake — and
+the `announce_only` band-aid added in 0.7.0 — are gone. Clients now
+declare the full set of tunnels in a single **session hello** right
+after QUIC connect, the server validates them in one shot, and every
+subsequent data-plane bi-stream identifies itself with a small
+**`OpenConn`** frame keyed by the server-assigned `tunnel_id`. This
+matches chisel's session-config model and fixes a real conceptual
+asymmetry: forward, reverse, and SOCKS dynamic streams now share a
+single declaration path.
+
+### Breaking
+
+- **Wire format is not backward compatible with 0.7.x.** A 0.8 client
+  speaking to a 0.7 server (or vice-versa) will fail at the first
+  handshake — there is no fallback. Upgrade both sides together.
+- **`RemoteRequest` lost its `announce_only` and `from_socks` fields**
+  along with the `dynamic_tcp` / `dynamic_udp` constructors.
+  Embedders that built `RemoteRequest`s by hand should drop those
+  fields; SOCKS-originated dynamic targets are now carried as
+  [`OpenConn::dynamic`] under a parent SOCKS5 tunnel, validated once
+  at hello time.
+- **Forward SOCKS5 with `--allow-socks=false` now fails the entire
+  session at hello time** instead of binding a local SOCKS listener
+  and rejecting individual CONNECTs. The operator (and the client
+  log) sees the rejection immediately.
+
+### Added
+
+- **`SessionHello { remotes: Vec<RemoteRequest> }`** plus
+  `SessionHelloResponse::{Ok { tunnel_ids }, Failed(_)}` exchanged on
+  the very first bi-stream of every QUIC connection. Reverse tunnels
+  spawn their server-side listener as soon as the hello is accepted —
+  no more lazy registration.
+- **`OpenConn { tunnel_id, dynamic: Option<DynamicTarget> }`** plus
+  `OpenConnResponse` framing the start of every data-plane
+  bi-stream. `dynamic` is populated only for SOCKS5 dynamic streams
+  (per-CONNECT TCP target, per-target UDP); static tunnels reuse the
+  declared `kind` from the hello.
+- **`server_receive_session_hello` / `server_reply_session_hello` /
+  `client_send_session_hello` / `send_open_conn` /
+  `receive_open_conn` / `reply_open_conn`** in
+  `src/common/tunnel.rs`. The legacy
+  `client_send_remote_request` / `server_receive_remote_request`
+  pair has been removed.
+- **`ServerState::register_tunnels`** — bulk-registers every tunnel
+  declared in one hello, returning the freshly minted entries in
+  declaration order. Replaces the deduplicating
+  `find_or_create_tunnel`; the per-client `tunnel_index` field is
+  gone.
+
+### Changed
+
+- **Tunnel handlers take a `tunnel_id: u64` argument.** Affects
+  `tunnel_tcp_client`, `tunnel_udp_client`, `tunnel_socks_client`.
+  The id is the server-assigned identifier from the hello reply
+  (forward) or the tunnel's own id used by the server to push reverse
+  conns (reverse).
+- **Server validates every requested remote up front** via
+  `validate_remotes` against `--allow-reverse` / `--allow-socks`.
+  First offending declaration short-circuits the whole session with
+  a single `RemoteFailed` reason instead of rejecting per-stream.
+- **No more per-tunnel control bi-stream.** Reverse declarations,
+  forward TCP/UDP "first conn", and the 0.7 announce stream all
+  collapse into the single hello + per-conn `OpenConn` model.
+
 ## [0.7.0] - 2026-05-03
 
 Phase-1 of the long-tracked **server admin API + CLI** README item: the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "rusnel"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +140,59 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -420,6 +490,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,12 +632,93 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -688,10 +848,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -828,6 +1000,12 @@ dependencies = [
  "base64",
  "serde_core",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -1029,22 +1207,28 @@ dependencies = [
 
 [[package]]
 name = "rusnel"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
+ "axum",
  "bytes",
  "clap",
  "dashmap",
  "dirs",
  "futures",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "quinn",
  "rcgen",
  "rmp-serde",
  "rustls",
  "rustls-pemfile",
  "serde",
+ "serde_json",
  "sha2",
  "tokio",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1157,6 +1341,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,6 +1421,42 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1319,6 +1545,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -1455,6 +1687,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,6 +1772,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,6 +1815,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1926,3 +2200,9 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusnel"
 description = "Rusnel is a fast TCP/UDP tunnel, transported over and encrypted using QUIC protocol. Single executable including both client and server"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/guyte149/Rusnel"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusnel"
 description = "Rusnel is a fast TCP/UDP tunnel, transported over and encrypted using QUIC protocol. Single executable including both client and server"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/guyte149/Rusnel"
@@ -28,6 +28,12 @@ rustls-pemfile = "2.2.0"
 dirs = "6.0.0"
 bytes = "1.11.1"
 dashmap = "6.1.0"
+serde_json = "1"
+axum = { version = "0.7", default-features = false, features = ["json", "tokio", "http1", "matched-path", "query"] }
+hyper = { version = "1", default-features = false, features = ["client", "server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio", "service"] }
+http-body-util = "0.1"
+tower = { version = "0.5", default-features = false, features = ["util"] }
 
 [lints.clippy]
 unwrap_used = "deny"

--- a/README.md
+++ b/README.md
@@ -160,6 +160,88 @@ servers reachable via a v6-preferring resolver still connect within
 ~250 ms. Server-side resources (including reverse-tunnel listeners) are
 released the moment the QUIC connection drops.
 
+## Server admin API & `rusnel ctl`
+
+The server exposes a read-only admin HTTP API on a unix domain socket
+**by default**: `~/.rusnel/admin.sock`, created with mode `0600` (the
+parent directory is auto-created on first use). Filesystem permissions
+are the only auth — only the user that started the server can connect.
+
+```bash
+rusnel server --tls-self-signed              # admin enabled at ~/.rusnel/admin.sock
+rusnel server --tls-self-signed --no-admin-socket             # opt out entirely
+rusnel server --tls-self-signed --admin-socket /run/rusnel-a.sock  # override path
+```
+
+`--admin-socket <path>` overrides the default path (handy when running
+multiple servers as the same user). `--no-admin-socket` disables the
+listener entirely. The two flags are mutually exclusive.
+
+### Terminology: client, tunnel, conn
+
+The admin API and `ctl` model state in three layers, each with one
+meaning:
+
+- A **client** is one connected client daemon (`rusnel client`)
+  talking to this server. Lives for the lifetime of the QUIC
+  connection.
+- A **tunnel** is the *remote declaration* a client established with
+  the server (`R:5000=>socks`, `1080=>1.1.1.1:53/udp`, …). Deduplicated
+  per client by spec, exists for the lifetime of the client, and
+  exposes cumulative byte counters across every conn that ever ran
+  through it.
+- A **conn** is a single proxied network connection going through a
+  tunnel — one accepted local TCP connection on a forward TCP tunnel,
+  one accepted remote TCP connection on a reverse TCP tunnel, one
+  per-source UDP flow, one SOCKS5 CONNECT, one SOCKS5 UDP target. Each
+  conn has its own live byte counters and a free-form `peer` label.
+
+Query the API with `rusnel ctl` (or `curl --unix-socket`):
+
+```bash
+rusnel ctl clients                       # tab-aligned table by default
+rusnel ctl client 3                      # client detail incl. its tunnels
+rusnel ctl client-conns 3                # active conns across all of client 3's tunnels
+rusnel ctl tunnels                       # every tunnel across every client
+rusnel ctl tunnel 7                      # tunnel detail + its active conns
+rusnel ctl tunnel-conns 7                # just the conns on tunnel 7
+rusnel ctl conns --json                  # every active conn, raw JSON
+rusnel ctl history --limit 20            # recent client disconnects
+```
+
+`ctl` defaults to the same `~/.rusnel/admin.sock` path the server uses,
+so the zero-flag pairing just works. Pass `--socket <path>` to override
+when the server runs on a non-default path.
+
+The available endpoints (`GET` only in this release):
+
+| Path                                  | Purpose                                                       |
+|---------------------------------------|---------------------------------------------------------------|
+| `/api/v1/server`                      | version, listen addr, uptime, client/tunnel/conn counts       |
+| `/api/v1/clients`                     | one row per connected client with rolled-up totals            |
+| `/api/v1/clients/:id`                 | client detail, with embedded tunnel summaries                 |
+| `/api/v1/clients/:id/tunnels`         | tunnels owned by one client                                   |
+| `/api/v1/clients/:id/conns`           | active conns across all of one client's tunnels               |
+| `/api/v1/tunnels`                     | every tunnel across every client                              |
+| `/api/v1/tunnels/:id`                 | tunnel detail with its active conns embedded                  |
+| `/api/v1/tunnels/:id/conns`           | just the active conns on one tunnel                           |
+| `/api/v1/conns`                       | every active conn globally                                    |
+| `/api/v1/conns/:id`                   | one conn by id                                                |
+| `/api/v1/history?limit=N`             | bounded ring buffer (256) of recent disconnects               |
+
+Each tunnel exposes both `active_bytes_in/out` (live, from currently
+open conns) and `bytes_in/out` (cumulative, including bytes from conns
+that have already closed), plus `active_conn_count` and `total_conns`
+(lifetime, including closed). Conns expose just their own
+`bytes_in/out`. All counters are tallied from the server's perspective:
+`bytes_in` is data received from the QUIC peer, `bytes_out` is data
+sent to it. Atomics use relaxed ordering — the API is observability,
+not a sync primitive, so a slightly stale read is fine.
+
+Write operations (kick client, kill conn), Prometheus `/metrics`, and
+an embedded web UI are tracked as phase-2 follow-ups in the TODO
+section.
+
 ## Authentication
 
 Both the server and the client require an explicit TLS-mode flag — there is
@@ -194,7 +276,7 @@ rusnel client --tls-ca   ./pki/ca.pem --tls-cert ./pki/client.pem --tls-key ./pk
 
 ### Embedded credentials (drop-and-run binaries)
 
-For Sliver-style "drop the binary onto a host and have it just work" deployments,
+For dro-and-run deployments,
 Rusnel can bake credentials and a default server address into the binary at
 **build time** via `RUSNEL_EMBED_*` env vars. The resulting binary runs in the
 appropriate TLS mode with no flags required (CLI flags still override embedded
@@ -268,11 +350,9 @@ the script adds for you). See [`benchmark/`](benchmark/) for tunables.
 - [ ] SSO / OIDC client auth via a `rusnel-issuer` daemon: client runs `rusnel client --sso https://issuer.corp.example`, completes a device-code flow against the org's IdP (Okta/Google/Auth0), and the issuer mints a short-lived (~8h) mTLS client cert with the user's email/groups in the SAN. Rusnel server only needs to trust the issuer's CA — no IdP knowledge in the data path. ACLs from the bullet above match on cert subject/groups.
 
 ### Operability
-- [ ] server admin API + CLI + web UI:
-  - typed `ServerState` (DashMap of clients/tunnels with bytes-in/out counters) populated from the existing per-connection / per-tunnel handlers.
-  - HTTP admin API on a unix socket (filesystem-perm gated) or TCP+mTLS: `GET /clients`, `GET /clients/:id/tunnels`, `GET /tunnels`, `DELETE /clients/:id` (kick), `GET /metrics` (Prometheus).
-  - `rusnel ctl clients|tunnels|kick` subcommand consuming that API.
-  - tiny embedded web UI (single `include_str!`'d HTML file, no JS framework) with a client/tunnel dashboard and bandwidth sparklines off `/metrics`.
+- [x] **server admin API (read-only) + CLI**: typed `ServerState` (DashMap of clients/tunnels/conns with cumulative + per-conn byte counters), HTTP admin API on a unix socket gated by filesystem perms (mode 0600), three-layer client/tunnel/conn model exposed via `rusnel ctl clients|client|client-conns|tunnels|tunnel|tunnel-conns|conns|history|server`. See "Server admin API & `rusnel ctl`" above.
+- [ ] **server admin API — phase 2**: `DELETE /clients/:id` (kick), `DELETE /tunnels/:id` (kill tunnel), `GET /metrics` (Prometheus exporter), optional TCP+mTLS transport so the API is reachable over the network with the same PKI as the tunnel control plane.
+- [ ] **embedded web UI**: tiny `include_str!`'d HTML file (no JS framework) with a client/tunnel dashboard and bandwidth sparklines off `/metrics`.
 
 ### Testing & CI
 - [ ] run `./benchmark/run.sh` on a self-hosted runner per release tag and commit the result PNGs back, so perf regressions surface in PRs

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -35,7 +35,7 @@ pub async fn run_async(config: ClientConfig) -> Result<()> {
 
     // Single ^C listener for the lifetime of the process. Sessions subscribe to
     // it so a shutdown wins over both an in-progress reconnect sleep and a
-    // running session.
+    // running connection.
     let (shutdown_tx, _) = broadcast::channel::<()>(1);
     let shutdown_tx_clone = shutdown_tx.clone();
     tokio::spawn(async move {
@@ -120,8 +120,8 @@ impl<'a> EndpointPool<'a> {
 /// when the first attempt is just a few RTTs slow.
 const HAPPY_EYEBALLS_DELAY: Duration = Duration::from_millis(250);
 
-/// Outer loop: connect, run a session until it dies, then reconnect with
-/// exponential backoff. Returns once shutdown is signalled, the session
+/// Outer loop: connect, run a connection until it dies, then reconnect with
+/// exponential backoff. Returns once shutdown is signalled, the connection
 /// completes cleanly, or `max_retries` is exhausted.
 async fn run_with_reconnect(
     endpoints: Option<&mut EndpointPool<'_>>,
@@ -173,7 +173,7 @@ async fn run_with_reconnect(
                 attempt = 0;
                 backoff = initial_backoff;
 
-                let outcome = run_session(connection, config, shutdown_tx).await;
+                let outcome = run_connection(connection, config, shutdown_tx).await;
                 match outcome {
                     SessionOutcome::Shutdown => return Ok(()),
                     SessionOutcome::Disconnected(reason) => {
@@ -319,9 +319,9 @@ enum SessionOutcome {
     Disconnected(String),
 }
 
-/// Run one connected session: spawn forward / reverse tunnels and wait for
+/// Run one connected client: spawn forward / reverse tunnels and wait for
 /// either the connection to die or shutdown.
-async fn run_session(
+async fn run_connection(
     connection: Connection,
     config: &ClientConfig,
     shutdown_tx: &broadcast::Sender<()>,
@@ -360,7 +360,7 @@ async fn run_session(
     let mut shutdown_rx = shutdown_tx.subscribe();
     let outcome = tokio::select! {
         _ = shutdown_rx.recv() => {
-            info!("Shutting down tunnel session and notifying server...");
+            info!("Shutting down client and notifying server...");
             // Close the QUIC connection with a non-zero application code and
             // a human-readable reason. The server logs this verbatim, so the
             // operator on the other end sees "client closed (code 130, client
@@ -401,9 +401,9 @@ async fn handle_remote_stream(quic_connection: Connection, remote: RemoteRequest
     }
 
     match &remote.kind {
-        RemoteKind::Socks5 { .. } => tunnel_socks_client(quic_connection, remote).await?,
-        RemoteKind::Tcp { .. } => tunnel_tcp_client(quic_connection, remote).await?,
-        RemoteKind::Udp { .. } => tunnel_udp_client(quic_connection, remote).await?,
+        RemoteKind::Socks5 { .. } => tunnel_socks_client(quic_connection, remote, None).await?,
+        RemoteKind::Tcp { .. } => tunnel_tcp_client(quic_connection, remote, None).await?,
+        RemoteKind::Udp { .. } => tunnel_udp_client(quic_connection, remote, None).await?,
     }
     Ok(())
 }
@@ -421,10 +421,10 @@ async fn client_accept_dynamic_reverse_remote(quic_connection: Connection) -> Re
             info!("reverse tunnel established");
             match (dynamic_remote.direction, &dynamic_remote.kind) {
                 (Direction::Reverse, RemoteKind::Tcp { .. }) => {
-                    tunnel_tcp_server(recv, send, dynamic_remote).await?;
+                    tunnel_tcp_server(recv, send, dynamic_remote, None).await?;
                 }
                 (Direction::Reverse, RemoteKind::Udp { .. }) => {
-                    tunnel_udp_server(recv, send, dynamic_remote).await?;
+                    tunnel_udp_server(recv, send, dynamic_remote, None).await?;
                 }
                 (Direction::Reverse, RemoteKind::Socks5 { .. }) => {
                     error!("server pushed a reverse SOCKS5 dynamic remote — should be Tcp/Udp");

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,10 +1,11 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use futures::stream::{FuturesUnordered, StreamExt};
 use quinn::{Connection, Endpoint, VarInt};
-use tokio::io::AsyncWriteExt;
 use tokio::sync::broadcast;
 use tokio::{signal, task};
 use tracing::{debug, error, info, info_span, warn, Instrument};
@@ -12,10 +13,12 @@ use tracing::{debug, error, info, info_span, warn, Instrument};
 use crate::common::quic::{
     client_server_name, create_client_endpoint, create_client_endpoint_via_proxy,
 };
-use crate::common::remote::{Direction, RemoteKind, RemoteRequest};
+use crate::common::remote::{
+    Direction, DynamicTarget, OpenConnResponse, RemoteKind, RemoteRequest, SessionHello,
+};
 use crate::common::socks::tunnel_socks_client;
 use crate::common::tcp::{tunnel_tcp_client, tunnel_tcp_server};
-use crate::common::tunnel::{client_send_remote_request, server_receive_remote_request};
+use crate::common::tunnel::{client_send_session_hello, receive_open_conn, reply_open_conn};
 use crate::common::udp::{tunnel_udp_client, tunnel_udp_server};
 use crate::{ClientConfig, ReconnectConfig};
 
@@ -319,22 +322,51 @@ enum SessionOutcome {
     Disconnected(String),
 }
 
-/// Run one connected client: spawn forward / reverse tunnels and wait for
-/// either the connection to die or shutdown.
+/// Run one connected client: send the session hello, spawn forward
+/// listeners (one task per `--remote`), spawn the reverse-conn accept
+/// loop, then wait for either the connection to die or shutdown.
 async fn run_connection(
     connection: Connection,
     config: &ClientConfig,
     shutdown_tx: &broadcast::Sender<()>,
 ) -> SessionOutcome {
+    // Negotiate the whole tunnel set in one shot. If the server
+    // rejects (policy violation, version mismatch, …) we surface that
+    // as a Disconnect — the reconnect loop will keep retrying.
+    let tunnel_ids = match send_session_hello(&connection, &config.remotes).await {
+        Ok(ids) => ids,
+        Err(e) => {
+            return SessionOutcome::Disconnected(format!("session hello failed: {e}"));
+        }
+    };
+    info!("session established with {} tunnel(s)", tunnel_ids.len());
+
+    // Map tunnel_id → declared remote so the reverse-accept loop can
+    // resolve OpenConn frames the server pushes back.
+    let remotes_by_id: Arc<HashMap<u64, RemoteRequest>> = Arc::new(
+        tunnel_ids
+            .iter()
+            .copied()
+            .zip(config.remotes.iter().cloned())
+            .collect(),
+    );
+
     let mut tasks = Vec::new();
 
-    for remote in config.remotes.clone() {
+    // Spawn a per-forward-remote listener task. Reverse remotes have
+    // nothing to bind on the client — their listener runs on the
+    // server, and conns flow back through the accept loop below.
+    for (remote, tunnel_id) in config.remotes.iter().zip(tunnel_ids.iter().copied()) {
+        if matches!(remote.direction, Direction::Reverse) {
+            continue;
+        }
+        let remote = remote.clone();
         let connection_clone = connection.clone();
-        let span = info_span!("tunnel", remote = %remote);
+        let span = info_span!("tunnel", tunnel_id = tunnel_id, remote = %remote);
 
         let task = task::spawn(
             async move {
-                if let Err(e) = handle_remote_stream(connection_clone, remote).await {
+                if let Err(e) = handle_forward_tunnel(connection_clone, remote, tunnel_id).await {
                     error!("failed: {}", e)
                 }
                 anyhow::Ok(())
@@ -345,11 +377,13 @@ async fn run_connection(
     }
 
     let connection_clone = connection.clone();
+    let remotes_for_accept = remotes_by_id.clone();
     let accept_reverse_task = tokio::spawn(async move {
         loop {
             let quic_connection = connection_clone.clone();
-            if let Err(e) = client_accept_dynamic_reverse_remote(quic_connection).await {
-                debug!("reverse tunnel accept loop ended: {}", e);
+            let remotes = remotes_for_accept.clone();
+            if let Err(e) = client_accept_reverse_conn(quic_connection, remotes).await {
+                debug!("reverse conn accept loop ended: {}", e);
                 break;
             }
         }
@@ -389,54 +423,173 @@ async fn run_connection(
     outcome
 }
 
-async fn handle_remote_stream(quic_connection: Connection, remote: RemoteRequest) -> Result<()> {
-    // Reverse remotes only register interest with the server here — actual
-    // tunnel data flows back through `client_accept_dynamic_reverse_remote`
-    // when the server opens a stream for an inbound connection.
-    if remote.is_reversed() {
-        let (mut send, mut recv) = quic_connection.open_bi().await?;
-        client_send_remote_request(&remote, &mut send, &mut recv).await?;
-        send.shutdown().await?;
-        return Ok(());
-    }
+/// Open the very first bi-stream of this QUIC connection and exchange
+/// the [`SessionHello`] / [`SessionHelloResponse`] pair. Returns the
+/// server-assigned `tunnel_id`s, in the same order as `remotes`.
+async fn send_session_hello(
+    quic_connection: &Connection,
+    remotes: &[RemoteRequest],
+) -> Result<Vec<u64>> {
+    let (mut send, mut recv) = quic_connection.open_bi().await?;
+    let hello = SessionHello {
+        remotes: remotes.to_vec(),
+    };
+    client_send_session_hello(&hello, &mut send, &mut recv).await
+}
 
+/// Drive the local listener for one *forward* tunnel. Each accepted
+/// local connection opens a fresh bi-stream and announces itself with
+/// an [`OpenConn`] keyed by `tunnel_id`; from there the existing
+/// `tunnel_*_client` helpers handle the data plane.
+async fn handle_forward_tunnel(
+    quic_connection: Connection,
+    remote: RemoteRequest,
+    tunnel_id: u64,
+) -> Result<()> {
     match &remote.kind {
-        RemoteKind::Socks5 { .. } => tunnel_socks_client(quic_connection, remote, None).await?,
-        RemoteKind::Tcp { .. } => tunnel_tcp_client(quic_connection, remote, None).await?,
-        RemoteKind::Udp { .. } => tunnel_udp_client(quic_connection, remote, None).await?,
+        RemoteKind::Socks5 { .. } => {
+            tunnel_socks_client(quic_connection, remote, None, tunnel_id).await?
+        }
+        RemoteKind::Tcp { .. } => {
+            tunnel_tcp_client(quic_connection, remote, None, tunnel_id).await?
+        }
+        RemoteKind::Udp { .. } => {
+            tunnel_udp_client(quic_connection, remote, None, tunnel_id).await?
+        }
     }
     Ok(())
 }
 
-async fn client_accept_dynamic_reverse_remote(quic_connection: Connection) -> Result<()> {
-    let stream = quic_connection.accept_bi().await?;
-    let (mut send, mut recv) = stream;
+/// Accept loop for *server-pushed* reverse conns. The server opens a
+/// bi-stream and sends an [`OpenConn`] frame; we look up the parent
+/// tunnel in `remotes_by_id` to decide how to dispatch (TCP/UDP, with
+/// a possible dynamic target for `R:socks`).
+async fn client_accept_reverse_conn(
+    quic_connection: Connection,
+    remotes_by_id: Arc<HashMap<u64, RemoteRequest>>,
+) -> Result<()> {
+    let (mut send, mut recv) = quic_connection.accept_bi().await?;
 
     tokio::spawn(async move {
-        let dynamic_remote =
-            server_receive_remote_request(&mut send, &mut recv, true, true).await?;
-        let remote_display = dynamic_remote.to_string();
-
-        async {
-            info!("reverse tunnel established");
-            match (dynamic_remote.direction, &dynamic_remote.kind) {
-                (Direction::Reverse, RemoteKind::Tcp { .. }) => {
-                    tunnel_tcp_server(recv, send, dynamic_remote, None).await?;
-                }
-                (Direction::Reverse, RemoteKind::Udp { .. }) => {
-                    tunnel_udp_server(recv, send, dynamic_remote, None).await?;
-                }
-                (Direction::Reverse, RemoteKind::Socks5 { .. }) => {
-                    error!("server pushed a reverse SOCKS5 dynamic remote — should be Tcp/Udp");
-                }
-                (Direction::Forward, _) => {
-                    error!("received dynamic remote that is not reversed!")
-                }
+        let open = match receive_open_conn(&mut recv).await {
+            Ok(o) => o,
+            Err(e) => {
+                error!("failed to read OpenConn frame: {e}");
+                return;
             }
-            anyhow::Ok(())
+        };
+
+        let parent = match remotes_by_id.get(&open.tunnel_id) {
+            Some(p) => p.clone(),
+            None => {
+                let _ = reply_open_conn(
+                    &mut send,
+                    &OpenConnResponse::Failed(format!("unknown tunnel id {}", open.tunnel_id)),
+                )
+                .await;
+                error!(
+                    "server pushed conn for unknown tunnel id {}",
+                    open.tunnel_id
+                );
+                return;
+            }
+        };
+
+        // Resolve the synthetic per-conn `RemoteRequest` the data
+        // plane handlers expect: static reverse tunnels reuse the
+        // tunnel's declared kind; reverse SOCKS5 takes the target
+        // from the OpenConn `dynamic` field instead.
+        let dispatch = match resolve_reverse_dispatch(&parent, open.dynamic) {
+            Ok(d) => d,
+            Err(e) => {
+                let _ = reply_open_conn(&mut send, &OpenConnResponse::Failed(e.to_string())).await;
+                error!("reverse OpenConn dispatch error: {e}");
+                return;
+            }
+        };
+
+        if let Err(e) = reply_open_conn(&mut send, &OpenConnResponse::Ok).await {
+            error!("failed to ack reverse OpenConn: {e}");
+            return;
         }
-        .instrument(info_span!("tunnel", remote = %remote_display))
-        .await
+
+        let span = info_span!("conn", tunnel_id = open.tunnel_id, remote = %dispatch);
+        async move {
+            info!("reverse conn opened");
+            let result = match dispatch {
+                ReverseDispatch::Tcp(req) => tunnel_tcp_server(recv, send, req, None).await,
+                ReverseDispatch::Udp(req) => tunnel_udp_server(recv, send, req, None).await,
+            };
+            if let Err(e) = result {
+                debug!("reverse conn ended: {e}");
+            }
+        }
+        .instrument(span)
+        .await;
     });
     Ok(())
+}
+
+enum ReverseDispatch {
+    Tcp(RemoteRequest),
+    Udp(RemoteRequest),
+}
+
+impl std::fmt::Display for ReverseDispatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReverseDispatch::Tcp(r) | ReverseDispatch::Udp(r) => write!(f, "{r}"),
+        }
+    }
+}
+
+fn resolve_reverse_dispatch(
+    parent: &RemoteRequest,
+    dynamic: Option<DynamicTarget>,
+) -> Result<ReverseDispatch> {
+    if !matches!(parent.direction, Direction::Reverse) {
+        return Err(anyhow!(
+            "server pushed conn on a forward tunnel ({parent}) — protocol error"
+        ));
+    }
+    match (&parent.kind, dynamic) {
+        (RemoteKind::Tcp { local, remote }, None) => Ok(ReverseDispatch::Tcp(RemoteRequest {
+            direction: Direction::Reverse,
+            kind: RemoteKind::Tcp {
+                local: *local,
+                remote: remote.clone(),
+            },
+        })),
+        (RemoteKind::Udp { local, remote }, None) => Ok(ReverseDispatch::Udp(RemoteRequest {
+            direction: Direction::Reverse,
+            kind: RemoteKind::Udp {
+                local: *local,
+                remote: remote.clone(),
+            },
+        })),
+        (RemoteKind::Socks5 { local }, Some(DynamicTarget::Tcp(target))) => {
+            Ok(ReverseDispatch::Tcp(RemoteRequest {
+                direction: Direction::Reverse,
+                kind: RemoteKind::Tcp {
+                    local: *local,
+                    remote: target,
+                },
+            }))
+        }
+        (RemoteKind::Socks5 { local }, Some(DynamicTarget::Udp(target))) => {
+            Ok(ReverseDispatch::Udp(RemoteRequest {
+                direction: Direction::Reverse,
+                kind: RemoteKind::Udp {
+                    local: *local,
+                    remote: target,
+                },
+            }))
+        }
+        (RemoteKind::Socks5 { .. }, None) => Err(anyhow!(
+            "server pushed reverse SOCKS5 conn without a dynamic target"
+        )),
+        (_, Some(_)) => Err(anyhow!(
+            "server pushed unexpected dynamic target on non-SOCKS reverse tunnel"
+        )),
+    }
 }

--- a/src/common/counted.rs
+++ b/src/common/counted.rs
@@ -1,0 +1,136 @@
+//! Byte-counting helpers for the data plane.
+//!
+//! [`TunnelCounters`] holds two atomics — bytes received from the QUIC peer
+//! (`bytes_in`) and bytes sent to the QUIC peer (`bytes_out`) — that the
+//! admin API exposes per [`crate::server::state::TunnelEntry`]. The
+//! per-tunnel handlers ([`crate::common::tcp`], [`crate::common::udp`],
+//! [`crate::common::socks`]) bump them on the hot path.
+//!
+//! For TCP-style copies [`CountedReader`] wraps an [`AsyncRead`] and bumps
+//! a counter by the number of bytes filled into the supplied [`ReadBuf`] on
+//! each successful poll. Datagram paths increment counters directly with
+//! the datagram length.
+
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, ReadBuf};
+
+/// Per-tunnel byte counters. The atomics are wrapped in [`Arc`]s so the
+/// data-plane wrappers ([`CountedReader`]) can share the *same* atomic
+/// with the [`crate::server::state::TunnelEntry`] held by the admin API —
+/// each handle is just an `Arc<AtomicU64>` clone.
+///
+/// Both atomics use [`Ordering::Relaxed`]: the admin API is an
+/// observability surface, not a sync primitive, so a slightly stale read
+/// is fine and we don't want to add memory-fence cost to the data plane.
+#[derive(Debug, Default)]
+pub struct TunnelCounters {
+    bytes_in: Arc<AtomicU64>,
+    bytes_out: Arc<AtomicU64>,
+}
+
+impl TunnelCounters {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Cloneable handle for incrementing `bytes_in` (data received from
+    /// the QUIC peer).
+    pub fn in_handle(&self) -> Arc<AtomicU64> {
+        Arc::clone(&self.bytes_in)
+    }
+
+    /// Cloneable handle for incrementing `bytes_out` (data sent to the
+    /// QUIC peer).
+    pub fn out_handle(&self) -> Arc<AtomicU64> {
+        Arc::clone(&self.bytes_out)
+    }
+
+    pub fn add_in(&self, n: u64) {
+        if n > 0 {
+            self.bytes_in.fetch_add(n, Ordering::Relaxed);
+        }
+    }
+
+    pub fn add_out(&self, n: u64) {
+        if n > 0 {
+            self.bytes_out.fetch_add(n, Ordering::Relaxed);
+        }
+    }
+
+    pub fn snapshot(&self) -> (u64, u64) {
+        (
+            self.bytes_in.load(Ordering::Relaxed),
+            self.bytes_out.load(Ordering::Relaxed),
+        )
+    }
+}
+
+/// AsyncRead wrapper that increments `counter` by the number of bytes the
+/// inner reader filled into the supplied [`ReadBuf`] on each successful
+/// poll. Requires `R: Unpin` so we can avoid pulling in `pin-project`.
+pub struct CountedReader<R> {
+    inner: R,
+    counter: Arc<AtomicU64>,
+}
+
+impl<R> CountedReader<R> {
+    pub fn new(inner: R, counter: Arc<AtomicU64>) -> Self {
+        Self { inner, counter }
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for CountedReader<R> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let before = buf.filled().len();
+        let res = Pin::new(&mut self.inner).poll_read(cx, buf);
+        if matches!(&res, Poll::Ready(Ok(()))) {
+            let delta = buf.filled().len().saturating_sub(before);
+            if delta > 0 {
+                self.counter.fetch_add(delta as u64, Ordering::Relaxed);
+            }
+        }
+        res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+
+    #[tokio::test]
+    async fn counted_reader_tallies_reads() {
+        let data = b"hello world".to_vec();
+        let counter = Arc::new(AtomicU64::new(0));
+        let mut r = CountedReader::new(&data[..], counter.clone());
+        let mut out = Vec::new();
+        r.read_to_end(&mut out).await.unwrap();
+        assert_eq!(out, data);
+        assert_eq!(counter.load(Ordering::Relaxed), data.len() as u64);
+    }
+
+    #[test]
+    fn add_in_out_atomically() {
+        let c = TunnelCounters::default();
+        c.add_in(10);
+        c.add_in(0);
+        c.add_out(5);
+        assert_eq!(c.snapshot(), (10, 5));
+    }
+
+    #[test]
+    fn handles_share_underlying_atomic() {
+        let c = TunnelCounters::default();
+        let h = c.in_handle();
+        h.fetch_add(7, Ordering::Relaxed);
+        assert_eq!(c.snapshot(), (7, 0));
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,3 +1,4 @@
+pub mod counted;
 pub mod proxy;
 pub mod quic;
 pub mod remote;

--- a/src/common/remote.rs
+++ b/src/common/remote.rs
@@ -86,43 +86,35 @@ impl RemoteKind {
     }
 }
 
-/// A single tunnel description. The wire payload is
-/// `(direction, kind, from_socks)` and dispatchers on either side consume it
-/// via `match` with no stringly-typed sentinels and no `_` placeholders.
+/// A single tunnel description (a *tunnel declaration*). One of these per
+/// `--remote` flag on the client CLI; sent to the server in bulk inside
+/// [`SessionHello`] right after the QUIC connection is established.
+///
+/// In the post-0.8 protocol the client never re-sends a `RemoteRequest`
+/// per data conn — once the server accepts the hello and assigns each
+/// declaration a `tunnel_id`, all subsequent bi-streams identify
+/// themselves with [`OpenConn`] frames keyed by that id.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct RemoteRequest {
     pub direction: Direction,
     pub kind: RemoteKind,
-    /// `true` when this remote was manufactured by a SOCKS5 handler as a
-    /// per-target dynamic tunnel (forward `socks` → per-CONNECT TCP target;
-    /// forward `socks` UDP ASSOCIATE → per-target UDP). Lets the server gate
-    /// SOCKS-originated traffic via `--allow-socks` even though, by the time
-    /// the request reaches the wire, its `kind` is a plain `Tcp` / `Udp`
-    /// pointing at whatever target the SOCKS client asked for.
-    ///
-    /// For static remotes (anything declared on the CLI) and for reverse
-    /// SOCKS5 listeners (which use `RemoteKind::Socks5` directly) this field
-    /// stays `false` — `is_socks()` already returns `true` for the latter
-    /// based on `kind`.
-    #[serde(default)]
-    pub from_socks: bool,
 }
 
 impl RemoteRequest {
     pub fn new(direction: Direction, kind: RemoteKind) -> Self {
-        Self {
-            direction,
-            kind,
-            from_socks: false,
-        }
+        Self { direction, kind }
     }
 
-    /// `true` if this remote represents SOCKS5 traffic — either a standalone
-    /// SOCKS5 listener (reverse `R:socks`) or a dynamic per-target stream
-    /// manufactured inside a forward SOCKS5 handler. The server uses this to
-    /// gate everything SOCKS-related behind a single `--allow-socks` flag.
+    /// `true` if this remote represents SOCKS5 traffic — a standalone
+    /// SOCKS5 listener declaration (`R:socks` for reverse, plain `socks`
+    /// for forward). Used by the server's hello-time validation to gate
+    /// SOCKS5 behind `--allow-socks`. Per-CONNECT / per-UDP-target
+    /// dynamic streams the SOCKS handler manufactures at runtime no
+    /// longer need their own flag — they are carried as
+    /// [`OpenConn::dynamic`] under a parent SOCKS5 tunnel, which was
+    /// already gated at hello time.
     pub fn is_socks(&self) -> bool {
-        self.from_socks || matches!(self.kind, RemoteKind::Socks5 { .. })
+        matches!(self.kind, RemoteKind::Socks5 { .. })
     }
 
     pub fn is_reversed(&self) -> bool {
@@ -145,39 +137,6 @@ impl RemoteRequest {
                 Some(remote.to_addr_string())
             }
             RemoteKind::Socks5 { .. } => None,
-        }
-    }
-
-    /// Build a TCP forward remote that reuses this remote's `local` and
-    /// `direction`. Used by the SOCKS handshake to manufacture a dynamic
-    /// per-connection remote whose target is whatever the SOCKS client
-    /// asked for.
-    pub fn dynamic_tcp(&self, target: HostPort) -> Self {
-        Self {
-            direction: self.direction,
-            kind: RemoteKind::Tcp {
-                local: self.kind.local(),
-                remote: target,
-            },
-            // Tag this as SOCKS-originated so the server's `--allow-socks`
-            // gate fires even though the wire-level `kind` looks like a
-            // plain TCP forward.
-            from_socks: true,
-        }
-    }
-
-    /// UDP variant of [`Self::dynamic_tcp`]: build a UDP forward remote that
-    /// reuses this remote's `local` and `direction`. Used by SOCKS5
-    /// `UDP ASSOCIATE` to manufacture a per-target dynamic remote whose
-    /// target is whatever the SOCKS UDP datagram header pointed at.
-    pub fn dynamic_udp(&self, target: HostPort) -> Self {
-        Self {
-            direction: self.direction,
-            kind: RemoteKind::Udp {
-                local: self.kind.local(),
-                remote: target,
-            },
-            from_socks: true,
         }
     }
 }
@@ -210,13 +169,70 @@ impl fmt::Display for RemoteRequest {
 
 impl SerdeHelper for RemoteRequest {}
 
-#[derive(Serialize, Deserialize, Debug)]
-pub enum RemoteResponse {
-    RemoteOk,
-    RemoteFailed(String),
+// ---------------------------------------------------------------------------
+// Session-level handshake (post-0.8 wire protocol)
+// ---------------------------------------------------------------------------
+//
+// Right after the QUIC connection is established the client opens its
+// first bi-stream and sends a [`SessionHello`] carrying *every* tunnel
+// declaration it wants. The server validates them all in one shot
+// against `--allow-reverse` / `--allow-socks` and either accepts the
+// whole batch — assigning one `tunnel_id` per declaration in the same
+// order — or rejects the entire session. Subsequent bi-streams (in
+// either direction) start with an [`OpenConn`] frame that names the
+// `tunnel_id` they belong to, so neither side ever re-sends a full
+// [`RemoteRequest`] on the data plane.
+
+/// First control frame the client sends on a fresh QUIC connection.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SessionHello {
+    pub remotes: Vec<RemoteRequest>,
 }
 
-impl SerdeHelper for RemoteResponse {}
+impl SerdeHelper for SessionHello {}
+
+/// Server's reply to [`SessionHello`]. On success, `tunnel_ids[i]` is
+/// the server-assigned id for `hello.remotes[i]`. On failure, the
+/// server closes the connection.
+#[derive(Serialize, Deserialize, Debug)]
+pub enum SessionHelloResponse {
+    Ok { tunnel_ids: Vec<u64> },
+    Failed(String),
+}
+
+impl SerdeHelper for SessionHelloResponse {}
+
+/// Per-conn opener. Sent on the first 4 + body bytes of every
+/// data-plane bi-stream (in either direction) so the receiving side
+/// knows which tunnel this conn belongs to without consulting any
+/// out-of-band state.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct OpenConn {
+    pub tunnel_id: u64,
+    /// SOCKS5-only: the per-CONNECT (TCP) or per-target (UDP) address
+    /// the SOCKS handshake just resolved. `None` for static tunnels
+    /// (the receiving side uses the parent tunnel's declared `kind`).
+    pub dynamic: Option<DynamicTarget>,
+}
+
+impl SerdeHelper for OpenConn {}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum DynamicTarget {
+    Tcp(HostPort),
+    Udp(HostPort),
+}
+
+/// Reply to an [`OpenConn`]. `Ok` = "go ahead, start streaming"; `Failed`
+/// surfaces a server-side reason (unknown tunnel id, dispatch error,
+/// …) so the conn can be torn down cleanly instead of timing out.
+#[derive(Serialize, Deserialize, Debug)]
+pub enum OpenConnResponse {
+    Ok,
+    Failed(String),
+}
+
+impl SerdeHelper for OpenConnResponse {}
 
 // ---------------------------------------------------------------------------
 // Parser
@@ -250,11 +266,7 @@ impl FromStr for RemoteRequest {
         let (protocol_hint, body) = parse_protocol(after_dir)?;
         let tokens = split_addr_tokens(body)?;
         let kind = tokens_to_kind(&tokens, protocol_hint)?;
-        Ok(RemoteRequest {
-            direction,
-            kind,
-            from_socks: false,
-        })
+        Ok(RemoteRequest { direction, kind })
     }
 }
 
@@ -716,15 +728,6 @@ mod tests {
     fn local_socket_addr_handles_ipv6() {
         let r = parse("[::1]:8080:example.com:80");
         assert_eq!(r.local_socket_addr().to_string(), "[::1]:8080");
-    }
-
-    #[test]
-    fn dynamic_tcp_inherits_local_and_direction() {
-        let parent = parse("R:5000:socks");
-        let dyn_remote = parent.dynamic_tcp(HostPort::new("upstream.example", 80));
-        assert!(dyn_remote.is_reversed());
-        assert!(matches!(dyn_remote.kind, RemoteKind::Tcp { .. }));
-        assert_eq!(dyn_remote.local_socket_addr(), parent.local_socket_addr());
     }
 
     #[test]

--- a/src/common/socks.rs
+++ b/src/common/socks.rs
@@ -12,7 +12,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, debug_span, error, info, warn, Instrument};
 
 use super::remote::{HostPort, RemoteRequest};
-use super::tcp::tunnel_tcp_stream;
+use super::tcp::{tunnel_tcp_stream, Counters, TunnelHandleOpt};
 use super::tunnel::client_send_remote_request;
 use super::udp::{read_datagram, write_datagram};
 use anyhow::{anyhow, Result};
@@ -26,12 +26,16 @@ const SOCKS_MAX_DATAGRAM: usize = 65_535;
 /// debug log) instead of blocking the receive loop.
 const SOCKS_UDP_CHANNEL_CAPACITY: usize = 4096;
 
-/// How long a per (src, target) UDP-over-SOCKS5 session may sit idle before
+/// How long a per (src, target) UDP-over-SOCKS5 conn may sit idle before
 /// we tear down the QUIC stream. Mirrors the static UDP forward timeout so
 /// the two paths age out resources in lockstep.
 const SOCKS_UDP_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
-pub async fn tunnel_socks_client(quic_connection: Connection, remote: RemoteRequest) -> Result<()> {
+pub async fn tunnel_socks_client(
+    quic_connection: Connection,
+    remote: RemoteRequest,
+    handle: TunnelHandleOpt,
+) -> Result<()> {
     let local_addr = remote.local_socket_addr();
     let listener = TcpListener::bind(local_addr).await?;
     info!("SOCKS5 listening on {}", local_addr);
@@ -42,6 +46,7 @@ pub async fn tunnel_socks_client(quic_connection: Connection, remote: RemoteRequ
         let (mut local_conn, peer_addr) = listener.accept().await?;
         let connection = quic_connection.clone();
         let remote = remote.clone();
+        let tunnel_handle = handle.clone();
         let conn_id = conn_counter.fetch_add(1, Ordering::Relaxed) + 1;
         let span = debug_span!("conn", id = conn_id, peer = %peer_addr);
 
@@ -60,7 +65,7 @@ pub async fn tunnel_socks_client(quic_connection: Connection, remote: RemoteRequ
 
                 match request {
                     SocksRequest::Connect(target) => {
-                        let dynamic_remote = remote.dynamic_tcp(target);
+                        let dynamic_remote = remote.dynamic_tcp(target.clone());
                         debug!(target_remote = %dynamic_remote, "SOCKS5 CONNECT");
 
                         let (send, recv) = match connection.open_bi().await {
@@ -71,17 +76,37 @@ pub async fn tunnel_socks_client(quic_connection: Connection, remote: RemoteRequ
                             }
                         };
 
-                        if let Err(e) =
-                            start_client_dynamic_tunnel(local_conn, send, recv, dynamic_remote)
-                                .await
+                        // One admin conn per SOCKS CONNECT, labelled
+                        // with the SOCKS client's source plus the target
+                        // it asked for so operators can spot which CONNECT
+                        // is blocking on what.
+                        let _conn_guard = tunnel_handle
+                            .as_ref()
+                            .map(|h| h.open_conn(Some(format!("{peer_addr}=>{target}"))));
+                        let counters = _conn_guard.as_ref().map(|g| g.counters());
+
+                        if let Err(e) = start_client_dynamic_tunnel(
+                            local_conn,
+                            send,
+                            recv,
+                            dynamic_remote,
+                            counters,
+                        )
+                        .await
                         {
                             error!("dynamic tunnel error: {}", e);
                         }
                     }
                     SocksRequest::UdpAssociate => {
                         debug!("SOCKS5 UDP ASSOCIATE");
-                        if let Err(e) =
-                            handle_socks_udp_associate(connection, local_conn, &remote).await
+                        if let Err(e) = handle_socks_udp_associate(
+                            connection,
+                            local_conn,
+                            &remote,
+                            tunnel_handle,
+                            peer_addr,
+                        )
+                        .await
                         {
                             error!("UDP ASSOCIATE error: {}", e);
                         }
@@ -98,6 +123,7 @@ async fn start_client_dynamic_tunnel(
     mut send_channel: SendStream,
     mut recv_channel: RecvStream,
     dynamic_remote: RemoteRequest,
+    counters: Counters,
 ) -> Result<()> {
     client_send_remote_request(&dynamic_remote, &mut send_channel, &mut recv_channel).await?;
 
@@ -105,7 +131,7 @@ async fn start_client_dynamic_tunnel(
         .write_all(&[0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
         .await?;
 
-    tunnel_tcp_stream(socks_conn, send_channel, recv_channel).await?;
+    tunnel_tcp_stream(socks_conn, send_channel, recv_channel, counters).await?;
 
     Ok(())
 }
@@ -214,6 +240,8 @@ async fn handle_socks_udp_associate(
     quic_connection: Connection,
     mut tcp_conn: TcpStream,
     original_remote: &RemoteRequest,
+    handle: TunnelHandleOpt,
+    socks_peer: SocketAddr,
 ) -> Result<()> {
     // Bind a UDP socket on the same local IP we listen on. Port 0 lets the
     // OS pick — we report the chosen port back to the SOCKS client in the
@@ -232,8 +260,11 @@ async fn handle_socks_udp_associate(
         let connection = quic_connection.clone();
         let remote = original_remote.clone();
         let socket = udp_socket.clone();
+        let handle = handle.clone();
         async move {
-            if let Err(e) = run_socks_udp_relay(connection, remote, socket).await {
+            if let Err(e) =
+                run_socks_udp_relay(connection, remote, socket, handle, socks_peer).await
+            {
                 debug!("UDP ASSOCIATE relay ended: {}", e);
             }
         }
@@ -281,13 +312,14 @@ async fn run_socks_udp_relay(
     quic_connection: Connection,
     remote: RemoteRequest,
     udp_socket: Arc<UdpSocket>,
+    handle: TunnelHandleOpt,
+    socks_peer: SocketAddr,
 ) -> Result<()> {
     // Key by (source, target): this preserves source isolation (so two
     // different SOCKS clients sharing the same association never see each
     // other's traffic) and target isolation (so replies on each per-target
     // QUIC stream can be wrapped with the correct DST.ADDR/PORT header).
-    let sessions: Arc<DashMap<(SocketAddr, HostPort), mpsc::Sender<Bytes>>> =
-        Arc::new(DashMap::new());
+    let conns: Arc<DashMap<(SocketAddr, HostPort), mpsc::Sender<Bytes>>> = Arc::new(DashMap::new());
 
     let mut buf = vec![0u8; SOCKS_MAX_DATAGRAM];
     loop {
@@ -301,10 +333,10 @@ async fn run_socks_udp_relay(
         };
 
         let key = (src, target.clone());
-        let mut existing = sessions.get(&key).map(|e| e.value().clone());
+        let mut existing = conns.get(&key).map(|e| e.value().clone());
         if let Some(tx) = &existing {
             if tx.is_closed() {
-                sessions.remove(&key);
+                conns.remove(&key);
                 existing = None;
             }
         }
@@ -312,21 +344,23 @@ async fn run_socks_udp_relay(
             Some(tx) => tx,
             None => {
                 let (tx, rx) = mpsc::channel(SOCKS_UDP_CHANNEL_CAPACITY);
-                sessions.insert(key.clone(), tx.clone());
-                spawn_socks_udp_session(
+                conns.insert(key.clone(), tx.clone());
+                spawn_socks_udp_conn(
                     quic_connection.clone(),
                     remote.clone(),
                     udp_socket.clone(),
                     src,
                     target.clone(),
                     rx,
-                    sessions.clone(),
+                    conns.clone(),
+                    handle.clone(),
+                    socks_peer,
                 );
                 tx
             }
         };
 
-        // UDP is unreliable: drop on backpressure or after the session
+        // UDP is unreliable: drop on backpressure or after the conn
         // terminated rather than blocking the receive loop.
         if let Err(e) = tx.try_send(Bytes::copy_from_slice(payload)) {
             debug!(peer = %src, target = %target, "dropping UDP datagram: {}", e);
@@ -335,35 +369,54 @@ async fn run_socks_udp_relay(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn spawn_socks_udp_session(
+fn spawn_socks_udp_conn(
     quic_connection: Connection,
     remote: RemoteRequest,
     udp_socket: Arc<UdpSocket>,
     source: SocketAddr,
     target: HostPort,
     rx: mpsc::Receiver<Bytes>,
-    sessions: Arc<DashMap<(SocketAddr, HostPort), mpsc::Sender<Bytes>>>,
+    conns: Arc<DashMap<(SocketAddr, HostPort), mpsc::Sender<Bytes>>>,
+    handle: TunnelHandleOpt,
+    socks_peer: SocketAddr,
 ) {
     let key = (source, target.clone());
     tokio::spawn(async move {
-        debug!(peer = %source, target = %target, "opening SOCKS5 UDP session");
-        if let Err(e) =
-            run_socks_udp_session(quic_connection, remote, udp_socket, source, target, rx).await
+        debug!(peer = %source, target = %target, "opening SOCKS5 UDP conn");
+        // One admin conn per (SOCKS-source, UDP-target) pair so the
+        // operator can spot a single greedy target over a shared
+        // SOCKS UDP association.
+        let _conn_guard = handle
+            .as_ref()
+            .map(|h| h.open_conn(Some(format!("{socks_peer}=>{target}"))));
+        let counters = _conn_guard.as_ref().map(|g| g.counters());
+        if let Err(e) = run_socks_udp_conn(
+            quic_connection,
+            remote,
+            udp_socket,
+            source,
+            target,
+            rx,
+            counters,
+        )
+        .await
         {
-            warn!(peer = %source, "SOCKS5 UDP session ended: {}", e);
+            warn!(peer = %source, "SOCKS5 UDP conn ended: {}", e);
         }
-        sessions.remove(&key);
-        debug!(peer = %key.0, target = %key.1, "SOCKS5 UDP session removed");
+        conns.remove(&key);
+        debug!(peer = %key.0, target = %key.1, "SOCKS5 UDP conn removed");
     });
 }
 
-async fn run_socks_udp_session(
+#[allow(clippy::too_many_arguments)]
+async fn run_socks_udp_conn(
     quic_connection: Connection,
     remote: RemoteRequest,
     udp_socket: Arc<UdpSocket>,
     source: SocketAddr,
     target: HostPort,
     mut rx: mpsc::Receiver<Bytes>,
+    counters: Counters,
 ) -> Result<()> {
     // Manufacture a UDP forward dynamic-remote pointing at the per-datagram
     // target the SOCKS client asked for, then drive the same length-prefixed
@@ -373,15 +426,20 @@ async fn run_socks_udp_session(
     client_send_remote_request(&dynamic_remote, &mut send_channel, &mut recv_channel).await?;
 
     // Forward SOCKS-side datagrams onto the QUIC stream until the rx side
-    // closes (relay loop dropped the session) or the session sits idle long
+    // closes (relay loop dropped the conn) or the conn sits idle long
     // enough to age out.
     let local_to_quic = async {
         loop {
             match tokio::time::timeout(SOCKS_UDP_IDLE_TIMEOUT, rx.recv()).await {
-                Ok(Some(payload)) => write_datagram(&mut send_channel, &payload).await?,
+                Ok(Some(payload)) => {
+                    write_datagram(&mut send_channel, &payload).await?;
+                    if let Some(c) = counters.as_ref() {
+                        c.add_out(payload.len() as u64);
+                    }
+                }
                 Ok(None) => return Ok::<(), anyhow::Error>(()),
                 Err(_) => {
-                    debug!(peer = %source, target = %target, "SOCKS5 UDP session idle timeout");
+                    debug!(peer = %source, target = %target, "SOCKS5 UDP conn idle timeout");
                     return Ok(());
                 }
             }
@@ -389,7 +447,7 @@ async fn run_socks_udp_session(
     };
 
     // Wrap each QUIC-arriving reply in a SOCKS5 UDP header naming this
-    // session's target, then send it to the original SOCKS client UDP
+    // conn's target, then send it to the original SOCKS client UDP
     // source.
     let quic_to_local = async {
         let mut buf = vec![0u8; SOCKS_MAX_DATAGRAM];
@@ -398,6 +456,9 @@ async fn run_socks_udp_session(
             let payload = read_datagram(&mut recv_channel, &mut buf).await?;
             wrap_socks_udp_reply(&target, payload, &mut wrap);
             udp_socket.send_to(&wrap, source).await?;
+            if let Some(c) = counters.as_ref() {
+                c.add_in(payload.len() as u64);
+            }
         }
     };
 
@@ -455,7 +516,7 @@ fn parse_socks_udp_header(buf: &[u8]) -> Result<(HostPort, &[u8])> {
 }
 
 /// Wrap a reply UDP payload with the SOCKS5 UDP datagram header, addressed
-/// from the target this session is talking to. Re-uses the supplied scratch
+/// from the target this conn is talking to. Re-uses the supplied scratch
 /// buffer so we don't allocate per reply.
 fn wrap_socks_udp_reply(target: &HostPort, payload: &[u8], buf: &mut Vec<u8>) {
     buf.clear();

--- a/src/common/socks.rs
+++ b/src/common/socks.rs
@@ -11,9 +11,9 @@ use tokio::net::{TcpListener, TcpStream, UdpSocket};
 use tokio::sync::mpsc;
 use tracing::{debug, debug_span, error, info, warn, Instrument};
 
-use super::remote::{HostPort, RemoteRequest};
+use super::remote::{DynamicTarget, HostPort, OpenConn, RemoteRequest};
 use super::tcp::{tunnel_tcp_stream, Counters, TunnelHandleOpt};
-use super::tunnel::client_send_remote_request;
+use super::tunnel::send_open_conn;
 use super::udp::{read_datagram, write_datagram};
 use anyhow::{anyhow, Result};
 
@@ -35,6 +35,7 @@ pub async fn tunnel_socks_client(
     quic_connection: Connection,
     remote: RemoteRequest,
     handle: TunnelHandleOpt,
+    tunnel_id: u64,
 ) -> Result<()> {
     let local_addr = remote.local_socket_addr();
     let listener = TcpListener::bind(local_addr).await?;
@@ -65,8 +66,7 @@ pub async fn tunnel_socks_client(
 
                 match request {
                     SocksRequest::Connect(target) => {
-                        let dynamic_remote = remote.dynamic_tcp(target.clone());
-                        debug!(target_remote = %dynamic_remote, "SOCKS5 CONNECT");
+                        debug!(target = %target, "SOCKS5 CONNECT");
 
                         let (send, recv) = match connection.open_bi().await {
                             Ok(stream) => stream,
@@ -83,14 +83,18 @@ pub async fn tunnel_socks_client(
                         let _conn_guard = tunnel_handle
                             .as_ref()
                             .map(|h| h.open_conn(Some(format!("{peer_addr}=>{target}"))));
+                        if let Some(g) = _conn_guard.as_ref() {
+                            info!(
+                                conn_id = g.id(),
+                                peer = %peer_addr,
+                                target = %target,
+                                "conn opened"
+                            );
+                        }
                         let counters = _conn_guard.as_ref().map(|g| g.counters());
 
                         if let Err(e) = start_client_dynamic_tunnel(
-                            local_conn,
-                            send,
-                            recv,
-                            dynamic_remote,
-                            counters,
+                            local_conn, send, recv, tunnel_id, target, counters,
                         )
                         .await
                         {
@@ -105,6 +109,7 @@ pub async fn tunnel_socks_client(
                             &remote,
                             tunnel_handle,
                             peer_addr,
+                            tunnel_id,
                         )
                         .await
                         {
@@ -122,10 +127,19 @@ async fn start_client_dynamic_tunnel(
     mut socks_conn: TcpStream,
     mut send_channel: SendStream,
     mut recv_channel: RecvStream,
-    dynamic_remote: RemoteRequest,
+    tunnel_id: u64,
+    target: HostPort,
     counters: Counters,
 ) -> Result<()> {
-    client_send_remote_request(&dynamic_remote, &mut send_channel, &mut recv_channel).await?;
+    send_open_conn(
+        &OpenConn {
+            tunnel_id,
+            dynamic: Some(DynamicTarget::Tcp(target)),
+        },
+        &mut send_channel,
+        &mut recv_channel,
+    )
+    .await?;
 
     socks_conn
         .write_all(&[0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
@@ -242,6 +256,7 @@ async fn handle_socks_udp_associate(
     original_remote: &RemoteRequest,
     handle: TunnelHandleOpt,
     socks_peer: SocketAddr,
+    tunnel_id: u64,
 ) -> Result<()> {
     // Bind a UDP socket on the same local IP we listen on. Port 0 lets the
     // OS pick — we report the chosen port back to the SOCKS client in the
@@ -258,12 +273,11 @@ async fn handle_socks_udp_associate(
     // Spawn the relay; abort it when the TCP control connection closes.
     let relay_handle = tokio::spawn({
         let connection = quic_connection.clone();
-        let remote = original_remote.clone();
         let socket = udp_socket.clone();
         let handle = handle.clone();
         async move {
             if let Err(e) =
-                run_socks_udp_relay(connection, remote, socket, handle, socks_peer).await
+                run_socks_udp_relay(connection, tunnel_id, socket, handle, socks_peer).await
             {
                 debug!("UDP ASSOCIATE relay ended: {}", e);
             }
@@ -310,7 +324,7 @@ async fn write_socks_udp_associate_reply(conn: &mut TcpStream, addr: SocketAddr)
 /// UDP framing and sent to the original SOCKS UDP source.
 async fn run_socks_udp_relay(
     quic_connection: Connection,
-    remote: RemoteRequest,
+    tunnel_id: u64,
     udp_socket: Arc<UdpSocket>,
     handle: TunnelHandleOpt,
     socks_peer: SocketAddr,
@@ -347,7 +361,7 @@ async fn run_socks_udp_relay(
                 conns.insert(key.clone(), tx.clone());
                 spawn_socks_udp_conn(
                     quic_connection.clone(),
-                    remote.clone(),
+                    tunnel_id,
                     udp_socket.clone(),
                     src,
                     target.clone(),
@@ -371,7 +385,7 @@ async fn run_socks_udp_relay(
 #[allow(clippy::too_many_arguments)]
 fn spawn_socks_udp_conn(
     quic_connection: Connection,
-    remote: RemoteRequest,
+    tunnel_id: u64,
     udp_socket: Arc<UdpSocket>,
     source: SocketAddr,
     target: HostPort,
@@ -389,10 +403,18 @@ fn spawn_socks_udp_conn(
         let _conn_guard = handle
             .as_ref()
             .map(|h| h.open_conn(Some(format!("{socks_peer}=>{target}"))));
+        if let Some(g) = _conn_guard.as_ref() {
+            info!(
+                conn_id = g.id(),
+                peer = %socks_peer,
+                target = %target,
+                "conn opened"
+            );
+        }
         let counters = _conn_guard.as_ref().map(|g| g.counters());
         if let Err(e) = run_socks_udp_conn(
             quic_connection,
-            remote,
+            tunnel_id,
             udp_socket,
             source,
             target,
@@ -411,19 +433,28 @@ fn spawn_socks_udp_conn(
 #[allow(clippy::too_many_arguments)]
 async fn run_socks_udp_conn(
     quic_connection: Connection,
-    remote: RemoteRequest,
+    tunnel_id: u64,
     udp_socket: Arc<UdpSocket>,
     source: SocketAddr,
     target: HostPort,
     mut rx: mpsc::Receiver<Bytes>,
     counters: Counters,
 ) -> Result<()> {
-    // Manufacture a UDP forward dynamic-remote pointing at the per-datagram
-    // target the SOCKS client asked for, then drive the same length-prefixed
-    // QUIC framing the static UDP forward path uses.
-    let dynamic_remote = remote.dynamic_udp(target.clone());
+    // Open a fresh QUIC bi-stream and announce it as a SOCKS5 dynamic
+    // UDP conn under the parent SOCKS5 tunnel — the server uses the
+    // attached `DynamicTarget::Udp(target)` to dial the right
+    // destination. Same length-prefixed datagram framing as the
+    // static UDP forward path beyond this point.
     let (mut send_channel, mut recv_channel) = quic_connection.open_bi().await?;
-    client_send_remote_request(&dynamic_remote, &mut send_channel, &mut recv_channel).await?;
+    send_open_conn(
+        &OpenConn {
+            tunnel_id,
+            dynamic: Some(DynamicTarget::Udp(target.clone())),
+        },
+        &mut send_channel,
+        &mut recv_channel,
+    )
+    .await?;
 
     // Forward SOCKS-side datagrams onto the QUIC stream until the rx side
     // closes (relay loop dropped the conn) or the conn sits idle long

--- a/src/common/tcp.rs
+++ b/src/common/tcp.rs
@@ -10,7 +10,8 @@ use tokio::{
 use tracing::{debug, debug_span, info, Instrument};
 
 use crate::common::counted::{CountedReader, TunnelCounters};
-use crate::common::tunnel::client_send_remote_request;
+use crate::common::remote::OpenConn;
+use crate::common::tunnel::send_open_conn;
 use crate::server::state::TunnelHandle;
 
 use super::remote::RemoteRequest;
@@ -128,6 +129,7 @@ pub async fn tunnel_tcp_client(
     quic_connection: Connection,
     remote: RemoteRequest,
     handle: TunnelHandleOpt,
+    tunnel_id: u64,
 ) -> Result<()> {
     // Use SocketAddr's Display so IPv6 literals come out bracketed
     // (`[::1]:8080`) — a manual `format!("{ip}:{port}")` on an IPv6
@@ -144,20 +146,34 @@ pub async fn tunnel_tcp_client(
         let span = debug_span!("conn", id = conn_id, peer = %addr);
 
         let connection = quic_connection.clone();
-        let remote = remote.clone();
         let handle = handle.clone();
         tokio::spawn(
             async move {
                 debug!("open");
                 let (mut send, mut recv) = connection.open_bi().await?;
 
-                client_send_remote_request(&remote, &mut send, &mut recv).await?;
+                // Tell the peer which tunnel this stream belongs to.
+                // Static TCP tunnels carry no `dynamic` payload — the
+                // peer already knows the target from the tunnel's
+                // declaration in the session hello.
+                send_open_conn(
+                    &OpenConn {
+                        tunnel_id,
+                        dynamic: None,
+                    },
+                    &mut send,
+                    &mut recv,
+                )
+                .await?;
 
                 // Register this accepted connection as a conn against
                 // the parent tunnel (when admin tracking is enabled).
                 // The `ConnGuard` removes it again on drop, regardless
                 // of how the stream below ends.
                 let _conn_guard = handle.as_ref().map(|h| h.open_conn(Some(addr.to_string())));
+                if let Some(g) = _conn_guard.as_ref() {
+                    info!(conn_id = g.id(), peer = %addr, "conn opened");
+                }
                 let counters = _conn_guard.as_ref().map(|g| g.counters());
 
                 tunnel_tcp_stream(local_socket, send, recv, counters).await?;

--- a/src/common/tcp.rs
+++ b/src/common/tcp.rs
@@ -1,14 +1,17 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 use anyhow::Result;
 use quinn::{Connection, RecvStream, SendStream};
 use tokio::{
-    io::{AsyncWriteExt, BufReader},
+    io::{AsyncRead, AsyncWriteExt, BufReader},
     net::{TcpListener, TcpStream},
 };
 use tracing::{debug, debug_span, info, Instrument};
 
+use crate::common::counted::{CountedReader, TunnelCounters};
 use crate::common::tunnel::client_send_remote_request;
+use crate::server::state::TunnelHandle;
 
 use super::remote::RemoteRequest;
 
@@ -19,10 +22,48 @@ use super::remote::RemoteRequest;
 /// to keep memory use bounded under many concurrent connections.
 const TUNNEL_COPY_BUF: usize = 256 * 1024;
 
+/// Optional per-conn byte counter the server registers (and the
+/// client passes through as `None`). One [`TunnelCounters`] instance
+/// per accepted local connection / forward bi-stream / SOCKS CONNECT;
+/// see [`crate::server::state::ConnEntry`] for the lifecycle.
+pub type Counters = Option<Arc<TunnelCounters>>;
+
+/// Optional handle the server passes into long-lived reverse handlers
+/// (which spawn one conn per accept). When `Some`, each accept
+/// registers a [`crate::server::state::ConnEntry`] via
+/// [`TunnelHandle::open_conn`] and bumps that conn's counters
+/// for the duration of its [`crate::server::state::ConnGuard`].
+pub type TunnelHandleOpt = Option<Arc<TunnelHandle>>;
+
+/// Wrap an `AsyncRead` so each successful read bumps the QUIC peer's
+/// `bytes_in` counter (data received from the peer).
+fn count_in<R: AsyncRead + Unpin + Send + 'static>(
+    inner: R,
+    counters: &Counters,
+) -> Box<dyn AsyncRead + Unpin + Send> {
+    match counters {
+        Some(c) => Box::new(CountedReader::new(inner, c.in_handle())),
+        None => Box::new(inner),
+    }
+}
+
+/// Wrap an `AsyncRead` so each successful read bumps the QUIC peer's
+/// `bytes_out` counter (data we'll forward to the peer).
+fn count_out<R: AsyncRead + Unpin + Send + 'static>(
+    inner: R,
+    counters: &Counters,
+) -> Box<dyn AsyncRead + Unpin + Send> {
+    match counters {
+        Some(c) => Box::new(CountedReader::new(inner, c.out_handle())),
+        None => Box::new(inner),
+    }
+}
+
 pub async fn tunnel_tcp_stream(
     tcp_stream: TcpStream,
     mut send_channel: SendStream,
     recv_channel: RecvStream,
+    counters: Counters,
 ) -> Result<()> {
     // Disable Nagle on the TCP leg of the tunnel. Tunneled traffic is opaque
     // to us, so coalescing small writes can deadlock for ~40ms against the
@@ -49,8 +90,15 @@ pub async fn tunnel_tcp_stream(
     // batched `BufReader` + `copy_buf` is strictly better today on every
     // workload we benchmark; revisit when quinn exposes a vectored read API
     // that returns several `Bytes` per await.
+    //
+    // The `count_*` wrappers tally bytes per direction into the shared
+    // tunnel counters when the server is tracking this tunnel. With no
+    // counters configured (client side, or admin disabled) they're plain
+    // pass-throughs.
+    let tcp_recv = count_out(tcp_recv, &counters);
+    let quic_recv = count_in(recv_channel, &counters);
     let mut tcp_recv = BufReader::with_capacity(TUNNEL_COPY_BUF, tcp_recv);
-    let mut quic_recv = BufReader::with_capacity(TUNNEL_COPY_BUF, recv_channel);
+    let mut quic_recv = BufReader::with_capacity(TUNNEL_COPY_BUF, quic_recv);
 
     let client_to_server = async {
         tokio::io::copy_buf(&mut tcp_recv, &mut send_channel).await?;
@@ -76,7 +124,11 @@ pub async fn tunnel_tcp_stream(
     Ok(())
 }
 
-pub async fn tunnel_tcp_client(quic_connection: Connection, remote: RemoteRequest) -> Result<()> {
+pub async fn tunnel_tcp_client(
+    quic_connection: Connection,
+    remote: RemoteRequest,
+    handle: TunnelHandleOpt,
+) -> Result<()> {
     // Use SocketAddr's Display so IPv6 literals come out bracketed
     // (`[::1]:8080`) — a manual `format!("{ip}:{port}")` on an IPv6
     // `IpAddr` produces `::1:8080`, which `TcpListener::bind` rejects.
@@ -93,6 +145,7 @@ pub async fn tunnel_tcp_client(quic_connection: Connection, remote: RemoteReques
 
         let connection = quic_connection.clone();
         let remote = remote.clone();
+        let handle = handle.clone();
         tokio::spawn(
             async move {
                 debug!("open");
@@ -100,7 +153,14 @@ pub async fn tunnel_tcp_client(quic_connection: Connection, remote: RemoteReques
 
                 client_send_remote_request(&remote, &mut send, &mut recv).await?;
 
-                tunnel_tcp_stream(local_socket, send, recv).await?;
+                // Register this accepted connection as a conn against
+                // the parent tunnel (when admin tracking is enabled).
+                // The `ConnGuard` removes it again on drop, regardless
+                // of how the stream below ends.
+                let _conn_guard = handle.as_ref().map(|h| h.open_conn(Some(addr.to_string())));
+                let counters = _conn_guard.as_ref().map(|g| g.counters());
+
+                tunnel_tcp_stream(local_socket, send, recv, counters).await?;
                 Ok::<(), anyhow::Error>(())
             }
             .instrument(span),
@@ -112,6 +172,7 @@ pub async fn tunnel_tcp_server(
     recv_channel: RecvStream,
     send_channel: SendStream,
     request: RemoteRequest,
+    counters: Counters,
 ) -> Result<()> {
     let remote_addr = request
         .remote_addr_string()
@@ -120,7 +181,7 @@ pub async fn tunnel_tcp_server(
     let tcp_stream = TcpStream::connect(&remote_addr).await?;
     debug!("connected to {}", remote_addr);
 
-    tunnel_tcp_stream(tcp_stream, send_channel, recv_channel).await?;
+    tunnel_tcp_stream(tcp_stream, send_channel, recv_channel, counters).await?;
 
     Ok(())
 }

--- a/src/common/tunnel.rs
+++ b/src/common/tunnel.rs
@@ -2,21 +2,37 @@
 //!
 //! QUIC streams are byte-oriented, so any control message exchanged on a
 //! stream must carry its own framing. We use a tiny `u32` little-endian
-//! length prefix followed by a JSON body (kept as JSON for now to limit the
-//! blast radius of this change — see issue #21 for a binary codec).
+//! length prefix followed by a MessagePack body (see [`SerdeHelper`]).
+//!
+//! Two control flows live on top of this framing:
+//!
+//! * **Session hello.** The first bi-stream of every QUIC connection
+//!   carries one [`SessionHello`] (client → server) and one
+//!   [`SessionHelloResponse`] (server → client). The server uses the
+//!   hello to validate every requested remote against `--allow-reverse`
+//!   / `--allow-socks` in one shot, assigns each declaration a stable
+//!   `tunnel_id`, and either accepts the whole batch or rejects the
+//!   session entirely. There is no half-accept.
+//!
+//! * **Conn opener.** Every subsequent data-plane bi-stream (in either
+//!   direction) opens with one [`OpenConn`] frame keyed by a previously
+//!   negotiated `tunnel_id`. The receiving side replies with one
+//!   [`OpenConnResponse`] and, on `Ok`, the bi-stream is handed off to
+//!   the data-plane handler — no further control framing.
 
 use anyhow::{anyhow, Context, Result};
 use quinn::{RecvStream, SendStream};
+use tokio::io::AsyncWriteExt;
 use tracing::debug;
 
-use crate::common::remote::RemoteResponse;
+use crate::common::remote::{OpenConn, OpenConnResponse, SessionHello, SessionHelloResponse};
 use crate::common::utils::SerdeHelper;
 
-use super::remote::RemoteRequest;
-
-/// Hard cap on a single control message body. Generous compared to anything
-/// the protocol actually sends today, but small enough that a malicious peer
-/// can't make us allocate gigabytes by lying about the length.
+/// Hard cap on a single control message body. Generous compared to
+/// anything the protocol actually sends today (the largest realistic
+/// payload is a [`SessionHello`] with a few dozen `RemoteRequest`s),
+/// but small enough that a malicious peer can't make us allocate
+/// gigabytes by lying about the length.
 const MAX_CONTROL_MSG: usize = 64 * 1024;
 
 async fn write_framed<T: SerdeHelper>(send: &mut SendStream, msg: &T) -> Result<()> {
@@ -45,53 +61,82 @@ async fn read_framed<T: SerdeHelper>(recv: &mut RecvStream) -> Result<T> {
     T::from_bytes(body)
 }
 
-pub async fn client_send_remote_request(
-    remote: &RemoteRequest,
-    send_channel: &mut SendStream,
-    recv_channel: &mut RecvStream,
-) -> Result<()> {
-    debug!("sending remote request");
-    write_framed(send_channel, remote).await?;
+// ---------------------------------------------------------------------------
+// Session-level hello
+// ---------------------------------------------------------------------------
 
-    let response: RemoteResponse = read_framed(recv_channel).await?;
-    match response {
-        RemoteResponse::RemoteFailed(err) => Err(anyhow!("Remote tunnel error: {}", err)),
-        RemoteResponse::RemoteOk => {
-            debug!("remote accepted");
-            Ok(())
+/// Client side of the hello: send the full tunnel-declaration batch
+/// and wait for the server's verdict. On success, returns the list of
+/// server-assigned `tunnel_id`s in the same order as `hello.remotes`.
+pub async fn client_send_session_hello(
+    hello: &SessionHello,
+    send: &mut SendStream,
+    recv: &mut RecvStream,
+) -> Result<Vec<u64>> {
+    debug!(remotes = hello.remotes.len(), "sending session hello");
+    write_framed(send, hello).await?;
+    send.shutdown().await?;
+    match read_framed::<SessionHelloResponse>(recv).await? {
+        SessionHelloResponse::Ok { tunnel_ids } => {
+            if tunnel_ids.len() != hello.remotes.len() {
+                return Err(anyhow!(
+                    "server returned {} tunnel ids for {} remotes",
+                    tunnel_ids.len(),
+                    hello.remotes.len()
+                ));
+            }
+            debug!(
+                "session accepted, {} tunnel(s) registered",
+                tunnel_ids.len()
+            );
+            Ok(tunnel_ids)
         }
+        SessionHelloResponse::Failed(reason) => Err(anyhow!("server rejected session: {reason}")),
     }
 }
 
-pub async fn server_receive_remote_request(
-    send_channel: &mut SendStream,
-    recv_channel: &mut RecvStream,
-    allow_reverse: bool,
-    allow_socks: bool,
-) -> Result<RemoteRequest> {
-    let request: RemoteRequest = read_framed(recv_channel).await?;
-    debug!("received remote request: {}", request);
+/// Server side of the hello: receive the batch. The caller is
+/// responsible for validating each remote (against `--allow-reverse` /
+/// `--allow-socks`), assigning ids, and replying with
+/// [`server_reply_session_hello`].
+pub async fn server_receive_session_hello(recv: &mut RecvStream) -> Result<SessionHello> {
+    let hello: SessionHello = read_framed(recv).await?;
+    debug!(remotes = hello.remotes.len(), "received session hello");
+    Ok(hello)
+}
 
-    if request.is_reversed() && !allow_reverse {
-        let response =
-            RemoteResponse::RemoteFailed(String::from("Reverse remotes are not allowed"));
-        write_framed(send_channel, &response).await?;
-        return Err(anyhow!("Reverse remotes are not allowed"));
+pub async fn server_reply_session_hello(
+    send: &mut SendStream,
+    response: &SessionHelloResponse,
+) -> Result<()> {
+    write_framed(send, response).await?;
+    send.shutdown().await?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Per-conn opener
+// ---------------------------------------------------------------------------
+
+/// Send an [`OpenConn`] on a freshly opened bi-stream and wait for the
+/// peer's verdict. On `Ok`, the stream is yours to use as a data-plane
+/// channel.
+pub async fn send_open_conn(
+    open: &OpenConn,
+    send: &mut SendStream,
+    recv: &mut RecvStream,
+) -> Result<()> {
+    write_framed(send, open).await?;
+    match read_framed::<OpenConnResponse>(recv).await? {
+        OpenConnResponse::Ok => Ok(()),
+        OpenConnResponse::Failed(reason) => Err(anyhow!("conn open rejected: {reason}")),
     }
+}
 
-    // Gates *all* SOCKS5 traffic — both reverse-SOCKS listener requests
-    // (`RemoteKind::Socks5`, used for `R:socks`) and forward-SOCKS dynamic
-    // per-target streams (`RemoteKind::Tcp` / `Udp` with `from_socks=true`,
-    // manufactured by the client's SOCKS5 handler on every CONNECT or
-    // UDP ASSOCIATE target). The combination means `R:socks` requires
-    // BOTH `--allow-reverse` (checked above) and `--allow-socks`, while
-    // forward `socks` requires just `--allow-socks`.
-    if request.is_socks() && !allow_socks {
-        let response = RemoteResponse::RemoteFailed(String::from("SOCKS5 remotes are not allowed"));
-        write_framed(send_channel, &response).await?;
-        return Err(anyhow!("SOCKS5 remotes are not allowed"));
-    }
+pub async fn receive_open_conn(recv: &mut RecvStream) -> Result<OpenConn> {
+    read_framed(recv).await
+}
 
-    write_framed(send_channel, &RemoteResponse::RemoteOk).await?;
-    Ok(request)
+pub async fn reply_open_conn(send: &mut SendStream, response: &OpenConnResponse) -> Result<()> {
+    write_framed(send, response).await
 }

--- a/src/common/udp.rs
+++ b/src/common/udp.rs
@@ -10,8 +10,9 @@ use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
+use crate::common::remote::OpenConn;
 use crate::common::tcp::{Counters, TunnelHandleOpt};
-use crate::common::tunnel::client_send_remote_request;
+use crate::common::tunnel::send_open_conn;
 
 use super::remote::RemoteRequest;
 
@@ -151,6 +152,7 @@ pub async fn tunnel_udp_client(
     quic_connection: Connection,
     remote: RemoteRequest,
     handle: TunnelHandleOpt,
+    tunnel_id: u64,
 ) -> Result<()> {
     let listen_addr = remote.local_socket_addr();
     let udp_socket = Arc::new(UdpSocket::bind(listen_addr).await?);
@@ -195,12 +197,12 @@ pub async fn tunnel_udp_client(
                 conns.insert(src, tx.clone());
                 spawn_udp_conn(
                     quic_connection.clone(),
-                    remote.clone(),
                     udp_socket.clone(),
                     src,
                     rx,
                     conns.clone(),
                     handle.clone(),
+                    tunnel_id,
                 );
                 tx
             }
@@ -217,12 +219,12 @@ pub async fn tunnel_udp_client(
 #[allow(clippy::too_many_arguments)]
 fn spawn_udp_conn(
     quic_connection: Connection,
-    remote: RemoteRequest,
     udp_socket: Arc<UdpSocket>,
     source: SocketAddr,
     rx: mpsc::Receiver<Bytes>,
     conns: Arc<DashMap<SocketAddr, mpsc::Sender<Bytes>>>,
     handle: TunnelHandleOpt,
+    tunnel_id: u64,
 ) {
     tokio::spawn(async move {
         debug!(peer = %source, "opening UDP conn");
@@ -231,9 +233,12 @@ fn spawn_udp_conn(
         let _conn_guard = handle
             .as_ref()
             .map(|h| h.open_conn(Some(source.to_string())));
+        if let Some(g) = _conn_guard.as_ref() {
+            info!(conn_id = g.id(), peer = %source, "conn opened");
+        }
         let counters = _conn_guard.as_ref().map(|g| g.counters());
         if let Err(e) =
-            run_udp_conn(quic_connection, remote, udp_socket, source, rx, counters).await
+            run_udp_conn(quic_connection, tunnel_id, udp_socket, source, rx, counters).await
         {
             warn!(peer = %source, "UDP conn ended: {}", e);
         }
@@ -244,14 +249,22 @@ fn spawn_udp_conn(
 
 async fn run_udp_conn(
     quic_connection: Connection,
-    remote: RemoteRequest,
+    tunnel_id: u64,
     udp_socket: Arc<UdpSocket>,
     source: SocketAddr,
     mut rx: mpsc::Receiver<Bytes>,
     counters: Counters,
 ) -> Result<()> {
     let (mut send_channel, mut recv_channel) = quic_connection.open_bi().await?;
-    client_send_remote_request(&remote, &mut send_channel, &mut recv_channel).await?;
+    send_open_conn(
+        &OpenConn {
+            tunnel_id,
+            dynamic: None,
+        },
+        &mut send_channel,
+        &mut recv_channel,
+    )
+    .await?;
 
     // Forward locally-received datagrams onto the QUIC stream until the local
     // sender goes silent for CONN_IDLE_TIMEOUT.

--- a/src/common/udp.rs
+++ b/src/common/udp.rs
@@ -10,6 +10,7 @@ use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
+use crate::common::tcp::{Counters, TunnelHandleOpt};
 use crate::common::tunnel::client_send_remote_request;
 
 use super::remote::RemoteRequest;
@@ -18,17 +19,17 @@ use super::remote::RemoteRequest;
 /// payload at 65 507 bytes; round up to a power of two for the buffer.
 const MAX_DATAGRAM: usize = 65_535;
 
-/// How long a per-source UDP session may sit idle (no packets in either
+/// How long a per-source UDP conn may sit idle (no packets in either
 /// direction) before we tear down the QUIC stream and free the entry. Long
 /// enough to outlast typical request/response patterns; short enough that
 /// `HashMap` doesn't grow unbounded under churn.
-const SESSION_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+const CONN_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Bound on per-session backpressure. UDP is unreliable, so on overflow we
+/// Bound on per-conn backpressure. UDP is unreliable, so on overflow we
 /// drop the datagram (with a debug log) rather than block the receive loop.
 /// Sized generously to absorb traffic bursts during the initial RTT it takes
 /// to open the per-source QUIC stream.
-const SESSION_CHANNEL_CAPACITY: usize = 4096;
+const CONN_CHANNEL_CAPACITY: usize = 4096;
 
 /// Total bytes the rolling `BytesMut` pool keeps reserved at a time.
 /// Empirically wide enough to amortize allocations when receivers are
@@ -77,13 +78,19 @@ pub async fn tunnel_udp_stream(
     udp_address: SocketAddr,
     send_channel: SendStream,
     recv_channel: RecvStream,
+    counters: Counters,
 ) -> Result<()> {
     // tokio::join! (not try_join!) so a write error in one direction does not
     // cancel an in-flight read in the other (#20 §3). UDP is unreliable so we
     // just log and let the connection close.
     let (l2q, q2l) = tokio::join!(
-        pump_socket_to_stream(udp_socket.clone(), udp_address, send_channel),
-        pump_stream_to_socket(udp_socket, udp_address, recv_channel),
+        pump_socket_to_stream(
+            udp_socket.clone(),
+            udp_address,
+            send_channel,
+            counters.clone()
+        ),
+        pump_stream_to_socket(udp_socket, udp_address, recv_channel, counters),
     );
     if let Err(e) = l2q {
         debug!("local→quic error: {}", e);
@@ -102,6 +109,7 @@ async fn pump_socket_to_stream(
     udp_socket: Arc<UdpSocket>,
     udp_address: SocketAddr,
     mut send: SendStream,
+    counters: Counters,
 ) -> Result<()> {
     let mut buf = vec![0u8; MAX_DATAGRAM];
     loop {
@@ -111,6 +119,12 @@ async fn pump_socket_to_stream(
             continue;
         }
         write_datagram(&mut send, &buf[..len]).await?;
+        // Datagrams pumped onto the QUIC stream count toward `bytes_out`
+        // (data we forward to the QUIC peer). UDP framing overhead is a
+        // few bytes per datagram and intentionally not included.
+        if let Some(c) = counters.as_ref() {
+            c.add_out(len as u64);
+        }
     }
 }
 
@@ -118,18 +132,26 @@ async fn pump_stream_to_socket(
     udp_socket: Arc<UdpSocket>,
     udp_address: SocketAddr,
     mut recv: RecvStream,
+    counters: Counters,
 ) -> Result<()> {
     let mut buf = vec![0u8; MAX_DATAGRAM];
     loop {
         let payload = read_datagram(&mut recv, &mut buf).await?;
         udp_socket.send_to(payload, &udp_address).await?;
+        if let Some(c) = counters.as_ref() {
+            c.add_in(payload.len() as u64);
+        }
     }
 }
 
 /// Client-side forward UDP: accept datagrams from any number of local
-/// senders and multiplex each source onto its own QUIC bi-stream. Sessions
-/// are torn down after `SESSION_IDLE_TIMEOUT` of inactivity.
-pub async fn tunnel_udp_client(quic_connection: Connection, remote: RemoteRequest) -> Result<()> {
+/// senders and multiplex each source onto its own QUIC bi-stream. Conns
+/// are torn down after `CONN_IDLE_TIMEOUT` of inactivity.
+pub async fn tunnel_udp_client(
+    quic_connection: Connection,
+    remote: RemoteRequest,
+    handle: TunnelHandleOpt,
+) -> Result<()> {
     let listen_addr = remote.local_socket_addr();
     let udp_socket = Arc::new(UdpSocket::bind(listen_addr).await?);
 
@@ -138,13 +160,13 @@ pub async fn tunnel_udp_client(quic_connection: Connection, remote: RemoteReques
     // DashMap (sharded RwLock) replaces a single global Mutex<HashMap> so the
     // per-source lookup on every received datagram doesn't serialize the
     // receive loop under high pps from many sources.
-    let sessions: Arc<DashMap<SocketAddr, mpsc::Sender<Bytes>>> = Arc::new(DashMap::new());
+    let conns: Arc<DashMap<SocketAddr, mpsc::Sender<Bytes>>> = Arc::new(DashMap::new());
 
     // Rolling `BytesMut` pool. Each iteration extends `recv_buf` back up to
     // `MAX_DATAGRAM`, reads into it, and hands the populated prefix to the
-    // session as a zero-copy frozen [`Bytes`] via `split_to(...).freeze()`.
+    // conn as a zero-copy frozen [`Bytes`] via `split_to(...).freeze()`.
     // The underlying allocation is shared (Arc-refcounted inside `Bytes`),
-    // so once a session has consumed its packet the bytes return to the
+    // so once a conn has consumed its packet the bytes return to the
     // pool instead of forcing a fresh allocation per inbound datagram
     // (#21 §3). When all outstanding handles point into a fully-consumed
     // arena, `reserve` on the next loop reuses it in place.
@@ -157,33 +179,34 @@ pub async fn tunnel_udp_client(quic_connection: Connection, remote: RemoteReques
         let (n, src) = udp_socket.recv_from(&mut recv_buf[..]).await?;
         let payload = recv_buf.split_to(n).freeze();
 
-        // Look up an existing session, or open a new one for this source.
-        // Drop the entry if its session has already terminated.
-        let mut existing = sessions.get(&src).map(|e| e.value().clone());
+        // Look up an existing conn, or open a new one for this source.
+        // Drop the entry if its conn has already terminated.
+        let mut existing = conns.get(&src).map(|e| e.value().clone());
         if let Some(tx) = &existing {
             if tx.is_closed() {
-                sessions.remove(&src);
+                conns.remove(&src);
                 existing = None;
             }
         }
         let sender = match existing {
             Some(tx) => tx,
             None => {
-                let (tx, rx) = mpsc::channel(SESSION_CHANNEL_CAPACITY);
-                sessions.insert(src, tx.clone());
-                spawn_udp_session(
+                let (tx, rx) = mpsc::channel(CONN_CHANNEL_CAPACITY);
+                conns.insert(src, tx.clone());
+                spawn_udp_conn(
                     quic_connection.clone(),
                     remote.clone(),
                     udp_socket.clone(),
                     src,
                     rx,
-                    sessions.clone(),
+                    conns.clone(),
+                    handle.clone(),
                 );
                 tx
             }
         };
 
-        // UDP is unreliable — if the session is backpressured or has already
+        // UDP is unreliable — if the conn is backpressured or has already
         // terminated, dropping the packet is correct.
         if let Err(e) = sender.try_send(payload) {
             debug!(peer = %src, "dropping UDP datagram: {}", e);
@@ -191,43 +214,59 @@ pub async fn tunnel_udp_client(quic_connection: Connection, remote: RemoteReques
     }
 }
 
-fn spawn_udp_session(
+#[allow(clippy::too_many_arguments)]
+fn spawn_udp_conn(
     quic_connection: Connection,
     remote: RemoteRequest,
     udp_socket: Arc<UdpSocket>,
     source: SocketAddr,
     rx: mpsc::Receiver<Bytes>,
-    sessions: Arc<DashMap<SocketAddr, mpsc::Sender<Bytes>>>,
+    conns: Arc<DashMap<SocketAddr, mpsc::Sender<Bytes>>>,
+    handle: TunnelHandleOpt,
 ) {
     tokio::spawn(async move {
-        debug!(peer = %source, "opening UDP session");
-        if let Err(e) = run_udp_session(quic_connection, remote, udp_socket, source, rx).await {
-            warn!(peer = %source, "UDP session ended: {}", e);
+        debug!(peer = %source, "opening UDP conn");
+        // Per-source UDP aggregator → one admin-side conn, scoped to
+        // the lifetime of the spawn.
+        let _conn_guard = handle
+            .as_ref()
+            .map(|h| h.open_conn(Some(source.to_string())));
+        let counters = _conn_guard.as_ref().map(|g| g.counters());
+        if let Err(e) =
+            run_udp_conn(quic_connection, remote, udp_socket, source, rx, counters).await
+        {
+            warn!(peer = %source, "UDP conn ended: {}", e);
         }
-        sessions.remove(&source);
-        debug!(peer = %source, "UDP session removed");
+        conns.remove(&source);
+        debug!(peer = %source, "UDP conn removed");
     });
 }
 
-async fn run_udp_session(
+async fn run_udp_conn(
     quic_connection: Connection,
     remote: RemoteRequest,
     udp_socket: Arc<UdpSocket>,
     source: SocketAddr,
     mut rx: mpsc::Receiver<Bytes>,
+    counters: Counters,
 ) -> Result<()> {
     let (mut send_channel, mut recv_channel) = quic_connection.open_bi().await?;
     client_send_remote_request(&remote, &mut send_channel, &mut recv_channel).await?;
 
     // Forward locally-received datagrams onto the QUIC stream until the local
-    // sender goes silent for SESSION_IDLE_TIMEOUT.
+    // sender goes silent for CONN_IDLE_TIMEOUT.
     let local_to_quic = async {
         loop {
-            match tokio::time::timeout(SESSION_IDLE_TIMEOUT, rx.recv()).await {
-                Ok(Some(payload)) => write_datagram(&mut send_channel, &payload).await?,
+            match tokio::time::timeout(CONN_IDLE_TIMEOUT, rx.recv()).await {
+                Ok(Some(payload)) => {
+                    write_datagram(&mut send_channel, &payload).await?;
+                    if let Some(c) = counters.as_ref() {
+                        c.add_out(payload.len() as u64);
+                    }
+                }
                 Ok(None) => return Ok::<(), anyhow::Error>(()), // sender side closed
                 Err(_) => {
-                    debug!(peer = %source, "UDP session idle timeout");
+                    debug!(peer = %source, "UDP conn idle timeout");
                     return Ok(());
                 }
             }
@@ -242,10 +281,13 @@ async fn run_udp_session(
         loop {
             let payload = read_datagram(&mut recv_channel, &mut buf).await?;
             udp_socket.send_to(payload, &source).await?;
+            if let Some(c) = counters.as_ref() {
+                c.add_in(payload.len() as u64);
+            }
         }
     };
 
-    // Either branch finishing tears the session down — UDP has no "half-close"
+    // Either branch finishing tears the conn down — UDP has no "half-close"
     // worth preserving here.
     tokio::select! {
         r = local_to_quic => r,
@@ -257,6 +299,7 @@ pub async fn tunnel_udp_server(
     recv_channel: RecvStream,
     send_channel: SendStream,
     request: RemoteRequest,
+    counters: Counters,
 ) -> Result<()> {
     let remote_addr: SocketAddr = request
         .remote_addr_string()
@@ -275,7 +318,14 @@ pub async fn tunnel_udp_server(
 
     debug!("connecting to {}", remote_addr);
 
-    tunnel_udp_stream(udp_socket, remote_addr, send_channel, recv_channel).await?;
+    tunnel_udp_stream(
+        udp_socket,
+        remote_addr,
+        send_channel,
+        recv_channel,
+        counters,
+    )
+    .await?;
 
     Ok(())
 }

--- a/src/ctl/mod.rs
+++ b/src/ctl/mod.rs
@@ -1,0 +1,455 @@
+//! `rusnel ctl` — read-only client for the admin HTTP API.
+//!
+//! Speaks plain HTTP/1.1 over a unix domain socket (default
+//! `$XDG_RUNTIME_DIR/rusnel-admin.sock`, fallback `/tmp/rusnel-admin-<uid>.sock`).
+//! Output is a tab-aligned table by default; pass `--json` to emit the
+//! upstream API payload verbatim.
+//!
+//! Kept deliberately small: one request per command, no streaming, no
+//! retries — the admin API is local-only by design.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use http_body_util::{BodyExt, Empty};
+use hyper::body::Bytes;
+use hyper::Request;
+use hyper_util::rt::TokioIo;
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::net::UnixStream;
+
+/// Pretty-print a [`Value`] as either the original JSON (when `json` is
+/// true) or one of the table layouts below.
+pub enum Format {
+    Json,
+    Table,
+}
+
+/// Resolve the default admin socket path: `~/.rusnel/admin.sock`. Both
+/// the `server` subcommand (when neither `--admin-socket` nor
+/// `--no-admin-socket` is passed) and `rusnel ctl` (when no `--socket`
+/// is passed) use this single helper so the two sides agree without the
+/// operator having to type the path.
+///
+/// Falls back to `/tmp/rusnel-admin-<uid>.sock` if the home directory
+/// can't be resolved (e.g. a stripped-down container with no `$HOME`).
+/// `~/.rusnel` already houses the persisted self-signed cert (see
+/// [`crate::common::tls`]); we co-locate the socket there for the same
+/// reasons: stable across reboots, owner-only by convention, and the
+/// directory is auto-created on first use.
+pub fn default_socket_path() -> PathBuf {
+    if let Some(home) = dirs::home_dir() {
+        return home.join(".rusnel").join("admin.sock");
+    }
+    let uid = libc_getuid();
+    PathBuf::from(format!("/tmp/rusnel-admin-{uid}.sock"))
+}
+
+// libc bindings would normally come from the `libc` crate; the only thing
+// we need is geteuid for the fallback socket path. Linking it directly via
+// `extern "C"` avoids pulling in the full `libc` crate as a dependency
+// just for one syscall.
+extern "C" {
+    fn geteuid() -> u32;
+}
+fn libc_getuid() -> u32 {
+    unsafe { geteuid() }
+}
+
+/// Issue a `GET <path>` against the admin socket and return the parsed
+/// JSON body. Errors out with HTTP status detail on non-2xx responses.
+pub async fn get(socket: &Path, path: &str) -> Result<Value> {
+    let stream = UnixStream::connect(socket)
+        .await
+        .with_context(|| format!("connecting to admin socket {}", socket.display()))?;
+
+    let io = TokioIo::new(stream);
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(io)
+        .await
+        .context("HTTP/1.1 handshake")?;
+
+    // Drive the connection in the background; sender owns request
+    // dispatch. We don't need the join handle's result — when the
+    // request finishes the connection drops naturally.
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    let req = Request::builder()
+        .method("GET")
+        .uri(path)
+        // The `Host` header is meaningless on a unix socket but hyper's
+        // HTTP/1 layer requires *something*; pick a sentinel so a
+        // misconfigured proxy can't be tricked into masquerading as us.
+        .header("host", "rusnel-admin.local")
+        .body(Empty::<Bytes>::new())
+        .context("building request")?;
+
+    let resp = sender.send_request(req).await.context("sending request")?;
+    let status = resp.status();
+    let body = resp
+        .collect()
+        .await
+        .context("reading response body")?
+        .to_bytes();
+    if !status.is_success() {
+        let msg = String::from_utf8_lossy(&body);
+        bail!("admin API returned {status}: {msg}");
+    }
+    let v: Value = serde_json::from_slice(&body)
+        .with_context(|| format!("parsing JSON response for GET {path}"))?;
+    Ok(v)
+}
+
+// ---------------------------------------------------------------------------
+// Tabular renderers. Each one expects the matching JSON shape produced by
+// `src/server/state.rs`; if the server bumps the schema, only these
+// helpers need to change. The `--json` path skips them entirely.
+// ---------------------------------------------------------------------------
+
+/// Format the `/api/v1/server` payload.
+#[derive(Debug, Deserialize)]
+struct ServerInfo {
+    version: String,
+    listen_addr: String,
+    started_at_ms: u64,
+    uptime_ms: u64,
+    client_count: usize,
+    tunnel_count: usize,
+    active_conn_count: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClientSummary {
+    id: u64,
+    remote: String,
+    connected_at_ms: u64,
+    tunnel_count: usize,
+    active_conn_count: u64,
+    total_conns: u64,
+    bytes_in: u64,
+    bytes_out: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClientDetail {
+    #[serde(flatten)]
+    summary: ClientSummary,
+    tunnels: Vec<TunnelRow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TunnelRow {
+    id: u64,
+    client_id: u64,
+    direction: String,
+    kind: String,
+    spec: String,
+    opened_at_ms: u64,
+    active_conn_count: u64,
+    total_conns: u64,
+    bytes_in: u64,
+    bytes_out: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct TunnelDetail {
+    #[serde(flatten)]
+    summary: TunnelRow,
+    conns: Vec<ConnRow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConnRow {
+    id: u64,
+    tunnel_id: u64,
+    client_id: u64,
+    opened_at_ms: u64,
+    peer: Option<String>,
+    bytes_in: u64,
+    bytes_out: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct HistoryRow {
+    client_id: u64,
+    remote: String,
+    connected_at_ms: u64,
+    disconnected_at_ms: u64,
+    reason: String,
+    bytes_in: u64,
+    bytes_out: u64,
+    total_conns: u64,
+}
+
+pub fn render_server(payload: Value, format: Format) -> Result<String> {
+    if matches!(format, Format::Json) {
+        return Ok(pretty(&payload));
+    }
+    let s: ServerInfo = serde_json::from_value(payload)?;
+    Ok(format!(
+        "version           {}\nlisten            {}\nstarted-at-ms     {}\nuptime-ms         {}\nclients           {}\ntunnels           {}\nactive-conns      {}",
+        s.version,
+        s.listen_addr,
+        s.started_at_ms,
+        s.uptime_ms,
+        s.client_count,
+        s.tunnel_count,
+        s.active_conn_count
+    ))
+}
+
+pub fn render_clients(payload: Value, format: Format) -> Result<String> {
+    if matches!(format, Format::Json) {
+        return Ok(pretty(&payload));
+    }
+    let rows: Vec<ClientSummary> = serde_json::from_value(payload)?;
+    let mut t = Table::new(&[
+        "ID",
+        "REMOTE",
+        "CONNECTED-MS",
+        "TUNNELS",
+        "ACTIVE",
+        "TOTAL",
+        "IN",
+        "OUT",
+    ]);
+    for r in rows {
+        t.row([
+            r.id.to_string(),
+            r.remote,
+            r.connected_at_ms.to_string(),
+            r.tunnel_count.to_string(),
+            r.active_conn_count.to_string(),
+            r.total_conns.to_string(),
+            r.bytes_in.to_string(),
+            r.bytes_out.to_string(),
+        ]);
+    }
+    Ok(t.render())
+}
+
+pub fn render_client_detail(payload: Value, format: Format) -> Result<String> {
+    if matches!(format, Format::Json) {
+        return Ok(pretty(&payload));
+    }
+    let d: ClientDetail = serde_json::from_value(payload)?;
+    let s = &d.summary;
+    let mut out = format!(
+        "id                {}\nremote            {}\nconnected-ms      {}\ntunnels           {}\nactive-conns      {}\ntotal-conns       {}\nbytes-in          {}\nbytes-out         {}\n",
+        s.id,
+        s.remote,
+        s.connected_at_ms,
+        s.tunnel_count,
+        s.active_conn_count,
+        s.total_conns,
+        s.bytes_in,
+        s.bytes_out
+    );
+    if !d.tunnels.is_empty() {
+        out.push('\n');
+        out.push_str(&render_tunnel_rows(d.tunnels));
+    }
+    Ok(out)
+}
+
+pub fn render_tunnel_detail(payload: Value, format: Format) -> Result<String> {
+    if matches!(format, Format::Json) {
+        return Ok(pretty(&payload));
+    }
+    let d: TunnelDetail = serde_json::from_value(payload)?;
+    let s = &d.summary;
+    let mut out = format!(
+        "id                {}\nclient            {}\ndirection         {}\nkind              {}\nspec              {}\nopened-ms         {}\nactive-conns      {}\ntotal-conns       {}\nbytes-in          {}\nbytes-out         {}\n",
+        s.id,
+        s.client_id,
+        s.direction,
+        s.kind,
+        s.spec,
+        s.opened_at_ms,
+        s.active_conn_count,
+        s.total_conns,
+        s.bytes_in,
+        s.bytes_out
+    );
+    if !d.conns.is_empty() {
+        out.push('\n');
+        out.push_str(&render_conn_rows(d.conns));
+    }
+    Ok(out)
+}
+
+pub fn render_conns(payload: Value, format: Format) -> Result<String> {
+    if matches!(format, Format::Json) {
+        return Ok(pretty(&payload));
+    }
+    let rows: Vec<ConnRow> = serde_json::from_value(payload)?;
+    Ok(render_conn_rows(rows))
+}
+
+fn render_conn_rows(rows: Vec<ConnRow>) -> String {
+    let mut t = Table::new(&["ID", "TUNNEL", "CLIENT", "OPENED-MS", "PEER", "IN", "OUT"]);
+    for r in rows {
+        t.row([
+            r.id.to_string(),
+            r.tunnel_id.to_string(),
+            r.client_id.to_string(),
+            r.opened_at_ms.to_string(),
+            r.peer.unwrap_or_else(|| "-".into()),
+            r.bytes_in.to_string(),
+            r.bytes_out.to_string(),
+        ]);
+    }
+    t.render()
+}
+
+pub fn render_tunnels(payload: Value, format: Format) -> Result<String> {
+    if matches!(format, Format::Json) {
+        return Ok(pretty(&payload));
+    }
+    let rows: Vec<TunnelRow> = serde_json::from_value(payload)?;
+    Ok(render_tunnel_rows(rows))
+}
+
+fn render_tunnel_rows(rows: Vec<TunnelRow>) -> String {
+    let mut t = Table::new(&[
+        "ID",
+        "CLIENT",
+        "DIR",
+        "KIND",
+        "SPEC",
+        "OPENED-MS",
+        "ACTIVE",
+        "TOTAL",
+        "IN",
+        "OUT",
+    ]);
+    for r in rows {
+        t.row([
+            r.id.to_string(),
+            r.client_id.to_string(),
+            r.direction,
+            r.kind,
+            r.spec,
+            r.opened_at_ms.to_string(),
+            r.active_conn_count.to_string(),
+            r.total_conns.to_string(),
+            r.bytes_in.to_string(),
+            r.bytes_out.to_string(),
+        ]);
+    }
+    t.render()
+}
+
+pub fn render_history(payload: Value, format: Format) -> Result<String> {
+    if matches!(format, Format::Json) {
+        return Ok(pretty(&payload));
+    }
+    let rows: Vec<HistoryRow> = serde_json::from_value(payload)?;
+    let mut t = Table::new(&[
+        "CLIENT",
+        "REMOTE",
+        "CONNECTED-MS",
+        "DISCONNECTED-MS",
+        "SESSIONS",
+        "IN",
+        "OUT",
+        "REASON",
+    ]);
+    for r in rows {
+        t.row([
+            r.client_id.to_string(),
+            r.remote,
+            r.connected_at_ms.to_string(),
+            r.disconnected_at_ms.to_string(),
+            r.total_conns.to_string(),
+            r.bytes_in.to_string(),
+            r.bytes_out.to_string(),
+            r.reason,
+        ]);
+    }
+    Ok(t.render())
+}
+
+fn pretty(v: &Value) -> String {
+    serde_json::to_string_pretty(v).unwrap_or_else(|_| v.to_string())
+}
+
+/// Tiny tab-aligned table renderer. Pads each column to the max width
+/// observed in that column, then joins rows with newlines. We don't pull
+/// in `tabwriter` for this — fewer transitive deps and the output is
+/// simple enough.
+struct Table {
+    headers: Vec<String>,
+    rows: Vec<Vec<String>>,
+}
+
+impl Table {
+    fn new(headers: &[&str]) -> Self {
+        Self {
+            headers: headers.iter().map(|s| s.to_string()).collect(),
+            rows: Vec::new(),
+        }
+    }
+
+    fn row<I: IntoIterator<Item = String>>(&mut self, cells: I) {
+        let row: Vec<String> = cells.into_iter().collect();
+        debug_assert_eq!(row.len(), self.headers.len());
+        self.rows.push(row);
+    }
+
+    fn render(&self) -> String {
+        let mut widths: Vec<usize> = self.headers.iter().map(|h| h.len()).collect();
+        for row in &self.rows {
+            for (i, cell) in row.iter().enumerate() {
+                if i < widths.len() && cell.len() > widths[i] {
+                    widths[i] = cell.len();
+                }
+            }
+        }
+        let mut out = String::new();
+        push_row(&mut out, &self.headers, &widths);
+        for row in &self.rows {
+            push_row(&mut out, row, &widths);
+        }
+        out
+    }
+}
+
+fn push_row(out: &mut String, cells: &[String], widths: &[usize]) {
+    for (i, cell) in cells.iter().enumerate() {
+        if i > 0 {
+            out.push_str("  ");
+        }
+        // Right-pad with spaces; last column doesn't need padding.
+        if i + 1 < cells.len() {
+            out.push_str(&format!("{:width$}", cell, width = widths[i]));
+        } else {
+            out.push_str(cell);
+        }
+    }
+    out.push('\n');
+}
+
+/// Top-level error for failed `ctl` invocations: extracts the most
+/// helpful message from a chain of [`anyhow::Error`] causes.
+pub fn flatten_error(e: anyhow::Error) -> String {
+    let mut s = format!("{e}");
+    for cause in e.chain().skip(1) {
+        s.push_str(": ");
+        s.push_str(&cause.to_string());
+    }
+    s
+}
+
+#[allow(dead_code)]
+pub fn ensure_socket_exists(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Err(anyhow!(
+            "admin socket {} does not exist. Is the rusnel server running with --admin-socket?",
+            path.display()
+        ));
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,14 @@ use common::remote::RemoteRequest;
 use common::tls::{ClientTlsConfig, ServerTlsConfig};
 use std::fmt;
 use std::net::{IpAddr, SocketAddr};
+use std::path::PathBuf;
 use std::time::Duration;
 use tracing::{error, info};
 
 pub mod cert;
 pub mod client;
 pub mod common;
+pub mod ctl;
 pub mod embedded;
 pub mod server;
 
@@ -37,6 +39,13 @@ pub struct ServerConfig {
     /// unlimited connections and exhaust file descriptors / memory. `None`
     /// means uncapped (the default; matches chisel's behaviour).
     pub max_connections: Option<usize>,
+    /// Path to a unix domain socket to expose the read-only admin HTTP
+    /// API on. `None` (the default) disables the admin API entirely. When
+    /// set, the server creates the socket file (with mode 0600 — owner-
+    /// only access, since access to the socket implies full read access
+    /// to client/tunnel metadata) and serves `GET /api/v1/...` on it. See
+    /// [`server::admin`] for the route table.
+    pub admin_socket: Option<PathBuf>,
 }
 
 /// The server address the client was asked to connect to. Carries the full

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,6 +243,22 @@ enum Mode {
         #[arg(long, value_name = "N", default_value_t = 0)]
         max_connections: usize,
 
+        /// Path to the admin HTTP API unix socket.
+        ///
+        /// Defaults to `~/.rusnel/admin.sock` (auto-created with mode
+        /// 0600). Pass `--no-admin-socket` to disable the admin API
+        /// entirely; pass an explicit path here to override the default
+        /// (e.g. when running multiple rusnel servers as the same uid).
+        /// Query the API with `rusnel ctl ...` or
+        /// `curl --unix-socket <path> http://x/api/v1/clients`.
+        #[arg(long, value_name = "PATH", conflicts_with = "no_admin_socket")]
+        admin_socket: Option<PathBuf>,
+
+        /// Disable the admin HTTP API. Mutually exclusive with
+        /// `--admin-socket`.
+        #[arg(long, default_value_t = false)]
+        no_admin_socket: bool,
+
         /// enable verbose logging
         #[arg(short('v'), long("verbose"), default_value_t = false)]
         is_verbose: bool,
@@ -388,6 +404,61 @@ sharing <remote-host>:<remote-port> from the client to the server\'s <local-host
     Cert {
         #[command(subcommand)]
         action: CertAction,
+    },
+    /// Query a running server's admin API over a unix socket.
+    ///
+    /// The server must be started with --admin-socket <path>. By default
+    /// `ctl` looks at $XDG_RUNTIME_DIR/rusnel-admin.sock (Linux) or
+    /// /tmp/rusnel-admin-<uid>.sock (macOS / no XDG); pass --socket to
+    /// override. Output defaults to a tab-aligned table; pass --json to
+    /// pipe the raw API response.
+    Ctl {
+        /// Path to the admin unix socket.
+        #[arg(long, value_name = "PATH")]
+        socket: Option<PathBuf>,
+        /// Print the raw JSON API response instead of a formatted table.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+        #[command(subcommand)]
+        action: CtlAction,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum CtlAction {
+    /// Print server info: version, listen address, uptime, client count.
+    Server,
+    /// List currently-connected clients.
+    Clients,
+    /// Show full detail (including tunnels) for one client.
+    Client {
+        /// Client id from `ctl clients`.
+        id: u64,
+    },
+    /// List active conns on one client (across all of its tunnels).
+    ClientConns {
+        /// Client id from `ctl clients`.
+        id: u64,
+    },
+    /// List every tunnel (remote declaration) across every client.
+    Tunnels,
+    /// Show full detail for one tunnel, including its active conns.
+    Tunnel {
+        /// Tunnel id from `ctl tunnels`.
+        id: u64,
+    },
+    /// List active conns going through one tunnel.
+    TunnelConns {
+        /// Tunnel id from `ctl tunnels`.
+        id: u64,
+    },
+    /// List every active conn across every tunnel.
+    Conns,
+    /// Recent client disconnects (most recent first).
+    History {
+        /// Cap on the number of rows to fetch.
+        #[arg(long, value_name = "N")]
+        limit: Option<usize>,
     },
 }
 
@@ -628,6 +699,8 @@ fn main() {
             tls_ca,
             congestion,
             max_connections,
+            admin_socket,
+            no_admin_socket,
             is_verbose,
             is_debug,
         } => {
@@ -667,6 +740,15 @@ fn main() {
                     None
                 } else {
                     Some(max_connections)
+                },
+                // Admin API is on by default at `~/.rusnel/admin.sock`
+                // — opt out with `--no-admin-socket`, override with
+                // `--admin-socket <PATH>`. Clap enforces the
+                // mutual-exclusion via `conflicts_with`.
+                admin_socket: if no_admin_socket {
+                    None
+                } else {
+                    Some(admin_socket.unwrap_or_else(rusnel::ctl::default_socket_path))
                 },
             };
             debug!("Initialized server with config: {:?}", server_config);
@@ -733,6 +815,24 @@ fn main() {
             debug!("Initialized client with config: {:?}", client_config);
             run_client(client_config);
         }
+        Mode::Ctl {
+            socket,
+            json,
+            action,
+        } => {
+            // ctl is a one-shot client; minimal logger so error messages
+            // surface but we don't pollute the formatted-table output.
+            tracing_subscriber::fmt()
+                .with_max_level(tracing::Level::WARN)
+                .with_target(false)
+                .without_time()
+                .init();
+            let socket_path = socket.unwrap_or_else(rusnel::ctl::default_socket_path);
+            if let Err(e) = run_ctl(&socket_path, json, action) {
+                eprintln!("ctl: {}", rusnel::ctl::flatten_error(e));
+                std::process::exit(1);
+            }
+        }
         Mode::Cert { action } => {
             // Cert generation is a one-shot tool, not a server. Use a minimal
             // INFO logger so file paths are visible without --verbose.
@@ -748,6 +848,61 @@ fn main() {
             }
         }
     }
+}
+
+fn run_ctl(socket: &std::path::Path, json: bool, action: CtlAction) -> anyhow::Result<()> {
+    use rusnel::ctl::{self, Format};
+    let format = if json { Format::Json } else { Format::Table };
+    let rt = tokio::runtime::Runtime::new()?;
+    let output = rt.block_on(async {
+        match action {
+            CtlAction::Server => {
+                let payload = ctl::get(socket, "/api/v1/server").await?;
+                ctl::render_server(payload, format)
+            }
+            CtlAction::Clients => {
+                let payload = ctl::get(socket, "/api/v1/clients").await?;
+                ctl::render_clients(payload, format)
+            }
+            CtlAction::Client { id } => {
+                let payload = ctl::get(socket, &format!("/api/v1/clients/{id}")).await?;
+                ctl::render_client_detail(payload, format)
+            }
+            CtlAction::ClientConns { id } => {
+                let payload = ctl::get(socket, &format!("/api/v1/clients/{id}/conns")).await?;
+                ctl::render_conns(payload, format)
+            }
+            CtlAction::Tunnels => {
+                let payload = ctl::get(socket, "/api/v1/tunnels").await?;
+                ctl::render_tunnels(payload, format)
+            }
+            CtlAction::Tunnel { id } => {
+                let payload = ctl::get(socket, &format!("/api/v1/tunnels/{id}")).await?;
+                ctl::render_tunnel_detail(payload, format)
+            }
+            CtlAction::TunnelConns { id } => {
+                let payload = ctl::get(socket, &format!("/api/v1/tunnels/{id}/conns")).await?;
+                ctl::render_conns(payload, format)
+            }
+            CtlAction::Conns => {
+                let payload = ctl::get(socket, "/api/v1/conns").await?;
+                ctl::render_conns(payload, format)
+            }
+            CtlAction::History { limit } => {
+                let path = match limit {
+                    Some(n) => format!("/api/v1/history?limit={n}"),
+                    None => "/api/v1/history".to_string(),
+                };
+                let payload = ctl::get(socket, &path).await?;
+                ctl::render_history(payload, format)
+            }
+        }
+    })?;
+    print!("{output}");
+    if !output.ends_with('\n') {
+        println!();
+    }
+    Ok(())
 }
 
 fn run_cert(action: CertAction) -> anyhow::Result<()> {

--- a/src/server/admin.rs
+++ b/src/server/admin.rs
@@ -1,0 +1,313 @@
+//! Read-only admin HTTP API exposed over a unix domain socket.
+//!
+//! Bound by [`super::run_async`] when the operator passes
+//! `--admin-socket <path>`. Routes live in [`router`] below; the listener
+//! and per-connection HTTP/1.1 plumbing live in [`serve`]. Auth is purely
+//! filesystem-based: the socket is created with mode `0600` so only the
+//! owner of the rusnel server process can connect.
+//!
+//! No write endpoints in phase 1 — see the project README's
+//! "server admin API + CLI + web UI" item for the planned phase-2 surface
+//! (kick client, kill conn, Prometheus metrics, embedded web UI).
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use axum::extract::{Path as AxumPath, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use hyper::server::conn::http1;
+use hyper_util::rt::TokioIo;
+use hyper_util::service::TowerToHyperService;
+use serde::Deserialize;
+use tokio::net::UnixListener;
+use tracing::{debug, info, warn};
+
+use super::state::{
+    self, server_info, ClientDetailDto, ClientSummaryDto, ConnDto, ServerInfoDto, ServerState,
+    TunnelDetailDto, TunnelDto,
+};
+
+/// Default cap on the `/api/v1/history` response when the caller doesn't
+/// pass `?limit=N`.
+const DEFAULT_HISTORY_LIMIT: usize = 50;
+
+/// Bind `path` as a unix domain socket and serve the admin API on it
+/// until the future is cancelled.
+///
+/// On bind we:
+///   1. unlink any pre-existing socket file (a previous server process
+///      may have died without cleaning up);
+///   2. bind the listener;
+///   3. chmod the socket to 0600 so peers without our uid can't connect.
+///
+/// The chmod step matters even though most distros honour `umask` — we
+/// can't rely on the operator's umask being tight, and the socket carries
+/// full read access to live client metadata.
+pub async fn serve(state: ServerState, path: &Path) -> Result<()> {
+    let listener = bind(path)?;
+    info!(socket = %path.display(), "admin API listening");
+    let router = router(state);
+    let path_owned: PathBuf = path.to_path_buf();
+    let result = accept_loop(listener, router).await;
+    if let Err(e) = std::fs::remove_file(&path_owned) {
+        debug!("failed to unlink admin socket on shutdown: {e}");
+    }
+    result
+}
+
+/// Bind the admin unix socket at `path`, tightening its mode to 0600
+/// before returning. Split out from [`serve`] so tests (and the
+/// integration test in `tests/admin.rs`) can drive bind in isolation.
+pub fn bind(path: &Path) -> Result<UnixListener> {
+    if path.exists() {
+        // A stale socket file from a previous run blocks `bind`. Clean it
+        // up; if removal fails, surface the error so the operator sees
+        // why we couldn't bind.
+        std::fs::remove_file(path)
+            .with_context(|| format!("removing stale admin socket {}", path.display()))?;
+    }
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating admin socket directory {}", parent.display()))?;
+        }
+    }
+    let listener = UnixListener::bind(path)
+        .with_context(|| format!("binding admin socket {}", path.display()))?;
+
+    // Tighten permissions to owner-only. set_permissions on a unix socket
+    // honours the standard mode bits.
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o600);
+    std::fs::set_permissions(path, perms)
+        .with_context(|| format!("chmod 0600 {}", path.display()))?;
+
+    Ok(listener)
+}
+
+async fn accept_loop(listener: UnixListener, router: Router) -> Result<()> {
+    loop {
+        let (stream, _addr) = match listener.accept().await {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("admin accept error: {e}");
+                continue;
+            }
+        };
+        let svc = router.clone();
+        // axum 0.7's `Router` is a `tower::Service<Request<Body>>`; wrap
+        // it for hyper via `TowerToHyperService`. http1 is sufficient —
+        // unix-socket clients can't negotiate ALPN/HTTP2 and we don't
+        // expose the API over TCP in phase 1.
+        tokio::spawn(async move {
+            let io = TokioIo::new(stream);
+            if let Err(e) = http1::Builder::new()
+                .serve_connection(io, TowerToHyperService::new(svc))
+                .await
+            {
+                debug!("admin connection ended: {e}");
+            }
+        });
+    }
+}
+
+fn router(state: ServerState) -> Router {
+    Router::new()
+        .route("/api/v1/server", get(get_server))
+        .route("/api/v1/clients", get(list_clients))
+        .route("/api/v1/clients/:id", get(get_client))
+        .route("/api/v1/clients/:id/tunnels", get(list_client_tunnels))
+        .route("/api/v1/clients/:id/conns", get(list_client_conns))
+        .route("/api/v1/tunnels", get(list_tunnels))
+        .route("/api/v1/tunnels/:id", get(get_tunnel))
+        .route("/api/v1/tunnels/:id/conns", get(list_tunnel_conns))
+        .route("/api/v1/conns", get(list_conns))
+        .route("/api/v1/conns/:id", get(get_conn))
+        .route("/api/v1/history", get(list_history))
+        .with_state(state)
+}
+
+async fn get_server(State(state): State<ServerState>) -> Json<ServerInfoDto> {
+    Json(server_info(&state))
+}
+
+async fn list_clients(State(state): State<ServerState>) -> Json<Vec<ClientSummaryDto>> {
+    let clients = state.clients_snapshot();
+    let mut out: Vec<ClientSummaryDto> = clients
+        .iter()
+        .map(|c| ClientSummaryDto::from_entry(c))
+        .collect();
+    out.sort_by_key(|c| c.id);
+    Json(out)
+}
+
+async fn get_client(
+    State(state): State<ServerState>,
+    AxumPath(id): AxumPath<u64>,
+) -> Result<Json<ClientDetailDto>, ApiError> {
+    let entry = state.client(id).ok_or(ApiError::NotFound)?;
+    let summary = ClientSummaryDto::from_entry(&entry);
+    let mut tunnels: Vec<TunnelDto> = entry
+        .tunnels
+        .iter()
+        .map(|t| TunnelDto::from_entry(t.value()))
+        .collect();
+    tunnels.sort_by_key(|t| t.id);
+    Ok(Json(ClientDetailDto { summary, tunnels }))
+}
+
+async fn list_client_tunnels(
+    State(state): State<ServerState>,
+    AxumPath(id): AxumPath<u64>,
+) -> Result<Json<Vec<TunnelDto>>, ApiError> {
+    let entry = state.client(id).ok_or(ApiError::NotFound)?;
+    let mut out: Vec<TunnelDto> = entry
+        .tunnels
+        .iter()
+        .map(|t| TunnelDto::from_entry(t.value()))
+        .collect();
+    out.sort_by_key(|t| t.id);
+    Ok(Json(out))
+}
+
+async fn list_tunnels(State(state): State<ServerState>) -> Json<Vec<TunnelDto>> {
+    let mut out: Vec<TunnelDto> = state
+        .tunnels_snapshot()
+        .iter()
+        .map(|t| TunnelDto::from_entry(t))
+        .collect();
+    out.sort_by_key(|t| (t.client_id, t.id));
+    Json(out)
+}
+
+async fn get_tunnel(
+    State(state): State<ServerState>,
+    AxumPath(id): AxumPath<u64>,
+) -> Result<Json<TunnelDetailDto>, ApiError> {
+    let entry = state.tunnel(id).ok_or(ApiError::NotFound)?;
+    let summary = TunnelDto::from_entry(&entry);
+    let mut conns: Vec<ConnDto> = entry
+        .conns
+        .iter()
+        .map(|c| ConnDto::from_entry(c.value()))
+        .collect();
+    conns.sort_by_key(|c| c.id);
+    Ok(Json(TunnelDetailDto { summary, conns }))
+}
+
+async fn list_tunnel_conns(
+    State(state): State<ServerState>,
+    AxumPath(id): AxumPath<u64>,
+) -> Result<Json<Vec<ConnDto>>, ApiError> {
+    let entry = state.tunnel(id).ok_or(ApiError::NotFound)?;
+    let mut out: Vec<ConnDto> = entry
+        .conns
+        .iter()
+        .map(|c| ConnDto::from_entry(c.value()))
+        .collect();
+    out.sort_by_key(|c| c.id);
+    Ok(Json(out))
+}
+
+async fn list_conns(State(state): State<ServerState>) -> Json<Vec<ConnDto>> {
+    let mut out: Vec<ConnDto> = state
+        .conns_snapshot()
+        .iter()
+        .map(|c| ConnDto::from_entry(c))
+        .collect();
+    out.sort_by_key(|c| (c.client_id, c.tunnel_id, c.id));
+    Json(out)
+}
+
+async fn get_conn(
+    State(state): State<ServerState>,
+    AxumPath(id): AxumPath<u64>,
+) -> Result<Json<ConnDto>, ApiError> {
+    let entry = state.conn(id).ok_or(ApiError::NotFound)?;
+    Ok(Json(ConnDto::from_entry(&entry)))
+}
+
+/// Conns across every tunnel of one client. Useful for "what is
+/// client X currently doing" without picking a specific tunnel id.
+async fn list_client_conns(
+    State(state): State<ServerState>,
+    AxumPath(id): AxumPath<u64>,
+) -> Result<Json<Vec<ConnDto>>, ApiError> {
+    let client = state.client(id).ok_or(ApiError::NotFound)?;
+    let mut out: Vec<ConnDto> = Vec::new();
+    for t in client.tunnels.iter() {
+        for c in t.value().conns.iter() {
+            out.push(ConnDto::from_entry(c.value()));
+        }
+    }
+    out.sort_by_key(|c| (c.tunnel_id, c.id));
+    Ok(Json(out))
+}
+
+#[derive(Debug, Deserialize)]
+struct HistoryQuery {
+    limit: Option<usize>,
+}
+
+async fn list_history(
+    State(state): State<ServerState>,
+    Query(q): Query<HistoryQuery>,
+) -> Json<Vec<state::HistoryEntry>> {
+    let limit = q.limit.unwrap_or(DEFAULT_HISTORY_LIMIT);
+    Json(state.history_snapshot(limit))
+}
+
+/// Slim error type so route handlers can `?` an `Option::None` lookup into
+/// a 404 response without pulling in `axum::http::Error` boilerplate.
+enum ApiError {
+    NotFound,
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        match self {
+            ApiError::NotFound => (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "not found"})),
+            )
+                .into_response(),
+        }
+    }
+}
+
+#[cfg(unix)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Bind on a tempdir path, observe `0600`, then clean up. Pure-OS
+    /// behaviour — no rusnel state involved. Uses a short `/tmp/...`
+    /// path because `sockaddr_un.sun_path` is only ~104 bytes on
+    /// macOS — a long `$TMPDIR` (the default on macOS) overflows.
+    #[tokio::test]
+    async fn socket_is_owner_only() {
+        let socket = short_socket_path("admin-mode");
+        let listener = bind(&socket).unwrap();
+        let mode = std::fs::metadata(&socket).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "socket file mode should be 0600, got {mode:o}");
+        drop(listener);
+        let _ = std::fs::remove_file(&socket);
+    }
+
+    fn short_socket_path(label: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        PathBuf::from(format!(
+            "/tmp/rusnel-{}-{}-{}.sock",
+            label,
+            std::process::id(),
+            nanos
+        ))
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,14 +14,18 @@ use tokio::task::JoinSet;
 use tracing::{debug, error, info, info_span, warn, Instrument};
 
 use crate::common::quic::create_server_endpoint;
-use crate::common::remote::{Direction, RemoteKind};
+use crate::common::remote::{
+    Direction, DynamicTarget, RemoteKind, RemoteRequest, SessionHelloResponse,
+};
 use crate::common::socks::tunnel_socks_client;
 use crate::common::tcp::{tunnel_tcp_client, tunnel_tcp_server};
-use crate::common::tunnel::server_receive_remote_request;
+use crate::common::tunnel::{
+    reply_open_conn, server_receive_session_hello, server_reply_session_hello,
+};
 use crate::common::udp::{tunnel_udp_client, tunnel_udp_server};
 use crate::ServerConfig;
 
-use self::state::{ServerState, TunnelHandle};
+use self::state::{ServerState, TunnelEntry, TunnelHandle};
 
 /// Application-level QUIC close codes the server uses. We pick chisel-ish
 /// values purely so the wire dumps from the two tools look similar; the QUIC
@@ -173,6 +177,53 @@ async fn handle_client_connection(
     let client_entry =
         state.register_client(client_id, connection.remote_address(), connection.clone());
 
+    // ---------------------------------------------------------------
+    // Session hello: the very first bi-stream the client opens carries
+    // its full set of tunnel declarations. Validate them as a batch and
+    // either accept the whole session (assigning `tunnel_id`s) or reject
+    // it. This replaces the legacy per-stream `RemoteRequest` handshake.
+    // ---------------------------------------------------------------
+    let hello_outcome = perform_session_hello(
+        &connection,
+        &state,
+        &client_entry,
+        allow_reverse,
+        allow_socks,
+    )
+    .await;
+    let registered_tunnels = match hello_outcome {
+        Ok(t) => t,
+        Err(e) => {
+            // Rejected sessions still count as a disconnect so they
+            // appear in /history. The QUIC connection itself is left
+            // for the client to close once it sees the failure reply.
+            error!("session hello rejected: {e}");
+            state.deregister_client(client_id, format!("hello rejected: {e}"));
+            return Err(e);
+        }
+    };
+
+    // Reverse handlers own long-lived local sockets — bind them as
+    // soon as the hello is accepted, before any conn flows. Forward
+    // tunnels are passive on the server side; their conns arrive as
+    // OpenConn frames on the per-conn loop below.
+    for tunnel in &registered_tunnels {
+        info!(
+            tunnel_id = tunnel.id,
+            spec = %tunnel.spec,
+            direction = ?tunnel.direction,
+            "tunnel registered"
+        );
+        if matches!(tunnel.direction, Direction::Reverse) {
+            spawn_reverse_handler(
+                connection.clone(),
+                state.clone(),
+                tunnel.clone(),
+                &mut tunnels,
+            );
+        }
+    }
+
     let outcome = loop {
         let quic_connection = connection.clone();
 
@@ -222,19 +273,11 @@ async fn handle_client_connection(
             Ok(s) => s,
         };
 
-        let state_for_tunnel = state.clone();
-        let client_for_tunnel = client_entry.clone();
-        let fut = handle_remote_stream(
-            quic_connection,
-            stream,
-            allow_reverse,
-            allow_socks,
-            state_for_tunnel,
-            client_for_tunnel,
-        );
+        let state_for_conn = state.clone();
+        let fut = handle_open_conn(stream, state_for_conn);
         tunnels.spawn(async move {
             if let Err(e) = fut.await {
-                error!("failed: {}", e);
+                error!("conn failed: {}", e);
             }
         });
     };
@@ -257,75 +300,218 @@ async fn handle_client_connection(
     outcome
 }
 
-async fn handle_remote_stream(
-    quic_connection: Connection,
-    (mut send, mut recv): (quinn::SendStream, quinn::RecvStream),
+/// Read the client's [`SessionHello`], validate every requested
+/// remote, and reply with the assigned `tunnel_id`s (or a failure).
+/// On success returns the freshly registered tunnel entries in the
+/// same order as `hello.remotes`.
+async fn perform_session_hello(
+    connection: &Connection,
+    state: &ServerState,
+    client: &Arc<state::ClientEntry>,
     allow_reverse: bool,
     allow_socks: bool,
+) -> Result<Vec<Arc<TunnelEntry>>> {
+    let (mut send, mut recv) = connection.accept_bi().await?;
+    let hello = server_receive_session_hello(&mut recv).await?;
+
+    if let Err(reason) = validate_remotes(&hello.remotes, allow_reverse, allow_socks) {
+        let resp = SessionHelloResponse::Failed(reason.clone());
+        let _ = server_reply_session_hello(&mut send, &resp).await;
+        return Err(anyhow::anyhow!(reason));
+    }
+
+    let tunnels = state.register_tunnels(client, &hello.remotes);
+    let tunnel_ids: Vec<u64> = tunnels.iter().map(|t| t.id).collect();
+    server_reply_session_hello(&mut send, &SessionHelloResponse::Ok { tunnel_ids }).await?;
+    Ok(tunnels)
+}
+
+/// Static validation of a hello batch against the server's policy.
+/// Returns the *first* offending reason — operators rarely care about
+/// the rest, and surfacing only one keeps the rejection log tidy.
+fn validate_remotes(
+    remotes: &[RemoteRequest],
+    allow_reverse: bool,
+    allow_socks: bool,
+) -> Result<(), String> {
+    for r in remotes {
+        if r.is_reversed() && !allow_reverse {
+            return Err(format!("Reverse remotes are not allowed ({r})"));
+        }
+        if r.is_socks() && !allow_socks {
+            return Err(format!("SOCKS5 remotes are not allowed ({r})"));
+        }
+    }
+    Ok(())
+}
+
+fn spawn_reverse_handler(
+    connection: Connection,
     state: ServerState,
-    client: Arc<state::ClientEntry>,
-) -> Result<()> {
-    let request =
-        server_receive_remote_request(&mut send, &mut recv, allow_reverse, allow_socks).await?;
-    let remote_display = request.to_string();
-
-    // Find-or-create the *tunnel* (the remote declaration) for this
-    // client. Multiple conns on the same forward TCP remote share
-    // a single tunnel entry; reverse tunnels show up here exactly once
-    // because the client only sends the control-plane handshake once.
-    let tunnel = state.find_or_create_tunnel(&client, &request);
-
-    async {
-        info!("tunnel established");
-
-        // Dispatch is a flat `(direction, kind)` match — the wire type
-        // is unambiguous, no string sentinels, no `_` placeholders.
-        // SOCKS5 forward is a configuration error (the tunnel target is
-        // decided by the *client's* per-connection handshake, so the
-        // server never owns a SOCKS listener) and we reject it
-        // explicitly.
-        //
-        // Sessions are registered differently per direction:
-        // * forward: the bi-stream IS the conn, so we open a
-        //   `ConnGuard` here and pass its counters to the data-plane
-        //   handler.
-        // * reverse: the bi-stream is the control-plane handshake; the
-        //   handler opens a long-lived listener and registers one
-        //   conn per accepted connection. We hand it a
-        //   [`TunnelHandle`] so it can do that without seeing
-        //   `ServerState`.
-        match (request.direction, &request.kind) {
-            (Direction::Forward, RemoteKind::Tcp { .. }) => {
-                let _conn = state.register_conn(&tunnel, None);
-                let counters = Some(_conn.counters());
-                tunnel_tcp_server(recv, send, request, counters).await?
-            }
-            (Direction::Reverse, RemoteKind::Tcp { .. }) => {
-                let handle = Some(Arc::new(TunnelHandle::new(state.clone(), tunnel.clone())));
-                tunnel_tcp_client(quic_connection, request, handle).await?
-            }
-            (Direction::Forward, RemoteKind::Udp { .. }) => {
-                let _conn = state.register_conn(&tunnel, None);
-                let counters = Some(_conn.counters());
-                tunnel_udp_server(recv, send, request, counters).await?
-            }
-            (Direction::Reverse, RemoteKind::Udp { .. }) => {
-                let handle = Some(Arc::new(TunnelHandle::new(state.clone(), tunnel.clone())));
-                tunnel_udp_client(quic_connection, request, handle).await?
-            }
-            (Direction::Reverse, RemoteKind::Socks5 { .. }) => {
-                let handle = Some(Arc::new(TunnelHandle::new(state.clone(), tunnel.clone())));
-                tunnel_socks_client(quic_connection, request, handle).await?
-            }
-            (Direction::Forward, RemoteKind::Socks5 { .. }) => {
-                return Err(anyhow::anyhow!(
-                    "forward SOCKS5 is a client-side concern; server should not have received this request"
-                ));
+    tunnel: Arc<TunnelEntry>,
+    tasks: &mut JoinSet<()>,
+) {
+    let handle = Arc::new(TunnelHandle::new(state, tunnel.clone()));
+    let span = info_span!(
+        "reverse",
+        tunnel_id = tunnel.id,
+        spec = %tunnel.spec,
+    );
+    tasks.spawn(
+        async move {
+            // Reconstruct the `RemoteRequest` from the stored tunnel
+            // declaration so the existing handlers (which still take a
+            // `RemoteRequest` for local-bind / target lookup) keep
+            // working unchanged.
+            let request = RemoteRequest {
+                direction: tunnel.direction,
+                kind: tunnel.kind.clone(),
+            };
+            let result = match &tunnel.kind {
+                RemoteKind::Tcp { .. } => {
+                    tunnel_tcp_client(connection, request, Some(handle), tunnel.id).await
+                }
+                RemoteKind::Udp { .. } => {
+                    tunnel_udp_client(connection, request, Some(handle), tunnel.id).await
+                }
+                RemoteKind::Socks5 { .. } => {
+                    tunnel_socks_client(connection, request, Some(handle), tunnel.id).await
+                }
+            };
+            if let Err(e) = result {
+                error!("reverse handler failed: {e}");
             }
         }
+        .instrument(span),
+    );
+}
 
-        Ok(())
+/// Per-conn dispatcher. Receives one [`OpenConn`] frame, looks up its
+/// parent tunnel, registers a `ConnGuard`, and hands the bi-stream off
+/// to the appropriate data-plane handler.
+async fn handle_open_conn(
+    (mut send, mut recv): (quinn::SendStream, quinn::RecvStream),
+    state: ServerState,
+) -> Result<()> {
+    use crate::common::remote::OpenConnResponse;
+    let open = crate::common::tunnel::receive_open_conn(&mut recv).await?;
+
+    let tunnel = match state.tunnel(open.tunnel_id) {
+        Some(t) => t,
+        None => {
+            let _ = reply_open_conn(
+                &mut send,
+                &OpenConnResponse::Failed(format!("unknown tunnel id {}", open.tunnel_id)),
+            )
+            .await;
+            return Err(anyhow::anyhow!("unknown tunnel id {}", open.tunnel_id));
+        }
+    };
+
+    // Resolve the per-conn target. Static tunnels carry it in
+    // `tunnel.kind`; SOCKS5 dynamic streams carry it in `open.dynamic`
+    // (per CONNECT or per UDP target the SOCKS handler just decoded).
+    let dispatch = match resolve_dispatch(&tunnel, open.dynamic.as_ref()) {
+        Ok(d) => d,
+        Err(e) => {
+            let _ = reply_open_conn(&mut send, &OpenConnResponse::Failed(e.to_string())).await;
+            return Err(e);
+        }
+    };
+
+    reply_open_conn(&mut send, &OpenConnResponse::Ok).await?;
+
+    let peer = dispatch.peer_label();
+    let _conn = state.register_conn(&tunnel, peer.clone());
+    info!(
+        conn_id = _conn.id(),
+        tunnel_id = tunnel.id,
+        peer = peer.as_deref().unwrap_or("-"),
+        "conn opened"
+    );
+    let counters = Some(_conn.counters());
+
+    async {
+        match dispatch {
+            ForwardDispatch::Tcp(req) => tunnel_tcp_server(recv, send, req, counters).await,
+            ForwardDispatch::Udp(req) => tunnel_udp_server(recv, send, req, counters).await,
+        }
     }
-    .instrument(info_span!("tunnel", remote = %remote_display))
+    .instrument(info_span!(
+        "conn",
+        tunnel_id = tunnel.id,
+        spec = %tunnel.spec,
+    ))
     .await
+}
+
+/// What the conn's data-plane handler will do, plus the synthetic
+/// `RemoteRequest` it expects (carrying `local`/`remote` already
+/// resolved). Reverse tunnels never end up here — they reach the
+/// data plane via [`spawn_reverse_handler`].
+enum ForwardDispatch {
+    Tcp(RemoteRequest),
+    Udp(RemoteRequest),
+}
+
+impl ForwardDispatch {
+    fn peer_label(&self) -> Option<String> {
+        match self {
+            ForwardDispatch::Tcp(r) | ForwardDispatch::Udp(r) => r.remote_addr_string(),
+        }
+    }
+}
+
+fn resolve_dispatch(
+    tunnel: &TunnelEntry,
+    dynamic: Option<&DynamicTarget>,
+) -> Result<ForwardDispatch> {
+    if !matches!(tunnel.direction, Direction::Forward) {
+        return Err(anyhow::anyhow!(
+            "OpenConn on reverse tunnel {} (server pushes reverse conns, not the client)",
+            tunnel.id
+        ));
+    }
+    match (&tunnel.kind, dynamic) {
+        (RemoteKind::Tcp { local, remote }, None) => Ok(ForwardDispatch::Tcp(RemoteRequest {
+            direction: Direction::Forward,
+            kind: RemoteKind::Tcp {
+                local: *local,
+                remote: remote.clone(),
+            },
+        })),
+        (RemoteKind::Udp { local, remote }, None) => Ok(ForwardDispatch::Udp(RemoteRequest {
+            direction: Direction::Forward,
+            kind: RemoteKind::Udp {
+                local: *local,
+                remote: remote.clone(),
+            },
+        })),
+        (RemoteKind::Socks5 { local }, Some(DynamicTarget::Tcp(target))) => {
+            Ok(ForwardDispatch::Tcp(RemoteRequest {
+                direction: Direction::Forward,
+                kind: RemoteKind::Tcp {
+                    local: *local,
+                    remote: target.clone(),
+                },
+            }))
+        }
+        (RemoteKind::Socks5 { local }, Some(DynamicTarget::Udp(target))) => {
+            Ok(ForwardDispatch::Udp(RemoteRequest {
+                direction: Direction::Forward,
+                kind: RemoteKind::Udp {
+                    local: *local,
+                    remote: target.clone(),
+                },
+            }))
+        }
+        (RemoteKind::Socks5 { .. }, None) => Err(anyhow::anyhow!(
+            "OpenConn on SOCKS5 tunnel {} requires a `dynamic` target",
+            tunnel.id
+        )),
+        (_, Some(_)) => Err(anyhow::anyhow!(
+            "OpenConn on tunnel {} carried unexpected dynamic target",
+            tunnel.id
+        )),
+    }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,3 +1,7 @@
+pub mod admin;
+pub mod state;
+
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -17,6 +21,8 @@ use crate::common::tunnel::server_receive_remote_request;
 use crate::common::udp::{tunnel_udp_client, tunnel_udp_server};
 use crate::ServerConfig;
 
+use self::state::{ServerState, TunnelHandle};
+
 /// Application-level QUIC close codes the server uses. We pick chisel-ish
 /// values purely so the wire dumps from the two tools look similar; the QUIC
 /// layer treats the numeric value as opaque.
@@ -25,9 +31,23 @@ const CLOSE_CODE_SERVER_SHUTDOWN: u32 = 0;
 pub async fn run_async(config: ServerConfig) -> Result<()> {
     let endpoint =
         create_server_endpoint(config.host, config.port, &config.tls, config.congestion)?;
-    info!("Listening on {}", endpoint.local_addr()?);
+    let listen_addr = endpoint.local_addr()?;
+    info!("Listening on {}", listen_addr);
 
-    let session_counter = AtomicUsize::new(0);
+    let client_counter = AtomicUsize::new(0);
+
+    // Shared observability state. Always allocated; the admin HTTP server is
+    // the only thing that's gated by `--admin-socket` because the data-plane
+    // counter cost (two atomic adds per read) is in the noise.
+    let state = ServerState::new(listen_addr);
+
+    // Optional admin HTTP listener bound to a unix socket. Spawned alongside
+    // the accept loop so a failure to bind / serve doesn't take the tunnel
+    // server down — we just log the error and keep running.
+    let admin_handle: Option<tokio::task::JoinHandle<()>> = config
+        .admin_socket
+        .as_ref()
+        .map(|path| spawn_admin(state.clone(), path.clone()));
 
     // Global connection-level cap. `quinn`'s `max_concurrent_bidi_streams`
     // bounds streams *within* a connection, but a peer can still open
@@ -52,14 +72,23 @@ pub async fn run_async(config: ServerConfig) -> Result<()> {
                 info!("Shutdown signal received. Closing endpoint and notifying clients...");
                 endpoint.close(VarInt::from_u32(CLOSE_CODE_SERVER_SHUTDOWN), b"server received ^C");
                 endpoint.wait_idle().await;
+                if let Some(h) = admin_handle {
+                    h.abort();
+                    // The admin task is responsible for unlinking its
+                    // socket file on shutdown; abort()ing while bound is
+                    // OK because it owns nothing the OS won't reap.
+                }
+                if let Some(path) = &config.admin_socket {
+                    let _ = std::fs::remove_file(path);
+                }
                 info!("server stopped");
                 return Ok(());
             }
             maybe_conn = endpoint.accept() => {
                 let Some(conn) = maybe_conn else { break };
-                let session_id = session_counter.fetch_add(1, Ordering::Relaxed) + 1;
+                let client_id = client_counter.fetch_add(1, Ordering::Relaxed) + 1;
                 let remote_addr = conn.remote_address();
-                let span = info_span!("session", id = session_id, remote = %remote_addr);
+                let span = info_span!("client", id = client_id, remote = %remote_addr);
 
                 // Try to claim a connection permit. If the cap is reached,
                 // refuse the new connection rather than queueing it — a
@@ -81,11 +110,21 @@ pub async fn run_async(config: ServerConfig) -> Result<()> {
                     None
                 };
 
-                let fut = handle_client_connection(conn, config.allow_reverse, config.allow_socks);
+                let allow_reverse = config.allow_reverse;
+                let allow_socks = config.allow_socks;
+                let state_for_client = state.clone();
                 tokio::spawn(
                     async move {
                         info!("client connected");
-                        match fut.await {
+                        match handle_client_connection(
+                            conn,
+                            allow_reverse,
+                            allow_socks,
+                            client_id as u64,
+                            state_for_client,
+                        )
+                        .await
+                        {
                             Ok(reason) => info!("client disconnected: {reason}"),
                             Err(e) => error!("connection failed: {e}"),
                         }
@@ -98,6 +137,14 @@ pub async fn run_async(config: ServerConfig) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn spawn_admin(state: ServerState, path: PathBuf) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        if let Err(e) = admin::serve(state, &path).await {
+            error!("admin API exited: {e:#}");
+        }
+    })
 }
 
 /// Per-connection accept loop. Returns `Ok(reason)` on a clean disconnect
@@ -114,16 +161,24 @@ async fn handle_client_connection(
     conn: quinn::Incoming,
     allow_reverse: bool,
     allow_socks: bool,
+    client_id: u64,
+    state: ServerState,
 ) -> Result<String> {
     let connection = conn.await?;
     let mut tunnels: JoinSet<()> = JoinSet::new();
+
+    // Register this client with the observability state for the lifetime
+    // of the QUIC connection. We hold an `Arc<ClientEntry>` so per-tunnel
+    // registrations don't have to look it up again.
+    let client_entry =
+        state.register_client(client_id, connection.remote_address(), connection.clone());
 
     let outcome = loop {
         let quic_connection = connection.clone();
 
         // Drive `tunnels.join_next` alongside `accept_bi` so finished tunnel
         // tasks are reaped (otherwise the set grows unbounded for long-lived
-        // sessions). The `if !tunnels.is_empty()` guard disables the join
+        // tunnel tasks). The `if !tunnels.is_empty()` guard disables the join
         // branch when there's nothing to reap, otherwise `join_next` would
         // immediately resolve to `None` and we'd spin.
         let stream_result = tokio::select! {
@@ -167,7 +222,16 @@ async fn handle_client_connection(
             Ok(s) => s,
         };
 
-        let fut = handle_remote_stream(quic_connection, stream, allow_reverse, allow_socks);
+        let state_for_tunnel = state.clone();
+        let client_for_tunnel = client_entry.clone();
+        let fut = handle_remote_stream(
+            quic_connection,
+            stream,
+            allow_reverse,
+            allow_socks,
+            state_for_tunnel,
+            client_for_tunnel,
+        );
         tunnels.spawn(async move {
             if let Err(e) = fut.await {
                 error!("failed: {}", e);
@@ -183,6 +247,13 @@ async fn handle_client_connection(
     if aborted > 0 {
         debug!("aborted {aborted} tunnel task(s) on disconnect");
     }
+
+    let reason = match &outcome {
+        Ok(r) => r.clone(),
+        Err(e) => format!("error: {e}"),
+    };
+    state.deregister_client(client_id, reason);
+
     outcome
 }
 
@@ -191,34 +262,60 @@ async fn handle_remote_stream(
     (mut send, mut recv): (quinn::SendStream, quinn::RecvStream),
     allow_reverse: bool,
     allow_socks: bool,
+    state: ServerState,
+    client: Arc<state::ClientEntry>,
 ) -> Result<()> {
     let request =
         server_receive_remote_request(&mut send, &mut recv, allow_reverse, allow_socks).await?;
     let remote_display = request.to_string();
 
+    // Find-or-create the *tunnel* (the remote declaration) for this
+    // client. Multiple conns on the same forward TCP remote share
+    // a single tunnel entry; reverse tunnels show up here exactly once
+    // because the client only sends the control-plane handshake once.
+    let tunnel = state.find_or_create_tunnel(&client, &request);
+
     async {
         info!("tunnel established");
 
-        // Dispatch is now a flat `(direction, kind)` match — the wire type
-        // is unambiguous, no string sentinels, no `_` placeholders. SOCKS5
-        // forward is a configuration error (the tunnel target is decided
-        // by the *client's* per-connection handshake, so the server never
-        // owns a SOCKS listener) and we reject it explicitly.
+        // Dispatch is a flat `(direction, kind)` match — the wire type
+        // is unambiguous, no string sentinels, no `_` placeholders.
+        // SOCKS5 forward is a configuration error (the tunnel target is
+        // decided by the *client's* per-connection handshake, so the
+        // server never owns a SOCKS listener) and we reject it
+        // explicitly.
+        //
+        // Sessions are registered differently per direction:
+        // * forward: the bi-stream IS the conn, so we open a
+        //   `ConnGuard` here and pass its counters to the data-plane
+        //   handler.
+        // * reverse: the bi-stream is the control-plane handshake; the
+        //   handler opens a long-lived listener and registers one
+        //   conn per accepted connection. We hand it a
+        //   [`TunnelHandle`] so it can do that without seeing
+        //   `ServerState`.
         match (request.direction, &request.kind) {
             (Direction::Forward, RemoteKind::Tcp { .. }) => {
-                tunnel_tcp_server(recv, send, request).await?
+                let _conn = state.register_conn(&tunnel, None);
+                let counters = Some(_conn.counters());
+                tunnel_tcp_server(recv, send, request, counters).await?
             }
             (Direction::Reverse, RemoteKind::Tcp { .. }) => {
-                tunnel_tcp_client(quic_connection, request).await?
+                let handle = Some(Arc::new(TunnelHandle::new(state.clone(), tunnel.clone())));
+                tunnel_tcp_client(quic_connection, request, handle).await?
             }
             (Direction::Forward, RemoteKind::Udp { .. }) => {
-                tunnel_udp_server(recv, send, request).await?
+                let _conn = state.register_conn(&tunnel, None);
+                let counters = Some(_conn.counters());
+                tunnel_udp_server(recv, send, request, counters).await?
             }
             (Direction::Reverse, RemoteKind::Udp { .. }) => {
-                tunnel_udp_client(quic_connection, request).await?
+                let handle = Some(Arc::new(TunnelHandle::new(state.clone(), tunnel.clone())));
+                tunnel_udp_client(quic_connection, request, handle).await?
             }
             (Direction::Reverse, RemoteKind::Socks5 { .. }) => {
-                tunnel_socks_client(quic_connection, request).await?
+                let handle = Some(Arc::new(TunnelHandle::new(state.clone(), tunnel.clone())));
+                tunnel_socks_client(quic_connection, request, handle).await?
             }
             (Direction::Forward, RemoteKind::Socks5 { .. }) => {
                 return Err(anyhow::anyhow!(

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1,0 +1,682 @@
+//! Server-side observability state.
+//!
+//! The data model is three layers, each with exactly one meaning:
+//!
+//! * [`ClientEntry`] — one **client**: a single connected client
+//!   daemon (`rusnel client`) talking to this server. Lives for as
+//!   long as the QUIC connection does.
+//! * [`TunnelEntry`] — one **tunnel**: a remote declaration the
+//!   client established with the server (`R:5000=>socks`,
+//!   `1080=>1.1.1.1:53/udp`, …). Deduplicated per client by spec, so
+//!   many conns on the same forward TCP remote share one tunnel.
+//!   Accumulates cumulative byte counters across every conn that ever
+//!   ran through it.
+//! * [`ConnEntry`] — one **conn**: a single proxied network
+//!   connection going through a tunnel. For forward TCP that's one
+//!   accepted local TCP socket; for reverse it's one accepted remote
+//!   TCP socket on the server side; for UDP it's a per-source
+//!   aggregator; for SOCKS5 it's a per-CONNECT or per-target UDP
+//!   relay. Carries its own live `bytes_in` / `bytes_out`.
+//!
+//! Lifecycle hooks (driven from [`super`]):
+//! * client connect → [`ServerState::register_client`]
+//! * control-plane handshake → [`ServerState::find_or_create_tunnel`]
+//! * data-plane stream / accepted-conn → [`ServerState::register_conn`]
+//!   (dropped via [`ConnGuard`])
+//! * client disconnect → [`ServerState::deregister_client`] which fans
+//!   out [`HistoryEntry`]s and cleans up tunnels + conns.
+
+use std::collections::VecDeque;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use dashmap::DashMap;
+use quinn::Connection;
+use serde::Serialize;
+
+use crate::common::counted::TunnelCounters;
+use crate::common::remote::{Direction, RemoteKind, RemoteRequest};
+
+/// Cap on the recent-disconnects ring buffer. Picked small so a long-running
+/// server doesn't accumulate unbounded state — operators wanting durable
+/// history should scrape the `/history` endpoint into their own store.
+pub const HISTORY_CAPACITY: usize = 256;
+
+fn unix_ms(t: SystemTime) -> u64 {
+    t.duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// Live state objects
+// ---------------------------------------------------------------------------
+
+/// Live per-client record.
+#[derive(Debug)]
+pub struct ClientEntry {
+    pub id: u64,
+    pub remote: SocketAddr,
+    pub connected_at: SystemTime,
+    /// Tunnels currently registered against this client. Deduped by
+    /// the spec string, so reconnects of the same forward tunnel share
+    /// an entry. Held as `Arc`s so the admin routes can grab a snapshot
+    /// without holding the shard lock across JSON serialization.
+    pub tunnels: DashMap<u64, Arc<TunnelEntry>>,
+    /// Auxiliary index `spec → tunnel_id` so [`ServerState::find_or_create_tunnel`]
+    /// can dedupe atomically via `DashMap::entry`. Without this, two
+    /// concurrent first-conns on the same forward TCP remote both
+    /// observe an empty `tunnels` map and each create a separate
+    /// tunnel entry.
+    tunnel_index: DashMap<String, u64>,
+    /// Live QUIC handle. Kept around for phase-2 write endpoints
+    /// (`DELETE /clients/:id` → `connection.close(...)`); no read path
+    /// dereferences it today.
+    #[allow(dead_code)]
+    pub conn: Connection,
+}
+
+impl ClientEntry {
+    /// `(active_bytes_in, active_bytes_out, cumulative_bytes_in, cumulative_bytes_out)`
+    /// summed across this client's tunnels.
+    pub fn totals(&self) -> ClientTotals {
+        let mut t = ClientTotals::default();
+        for entry in self.tunnels.iter() {
+            let tot = entry.value().totals();
+            t.active_in += tot.active_in;
+            t.active_out += tot.active_out;
+            t.cumulative_in += tot.cumulative_in;
+            t.cumulative_out += tot.cumulative_out;
+            t.active_conns += tot.active_conns;
+            t.total_conns += tot.total_conns;
+        }
+        t
+    }
+}
+
+/// Live per-tunnel record (a remote declaration).
+#[derive(Debug)]
+pub struct TunnelEntry {
+    pub id: u64,
+    pub client_id: u64,
+    pub direction: Direction,
+    pub kind: RemoteKind,
+    /// Human-readable spec produced by [`RemoteRequest`]'s `Display`,
+    /// e.g. `R:5000=>socks` or `1080=>1.1.1.1:53/udp`.
+    pub spec: String,
+    pub opened_at: SystemTime,
+    /// Active conns, keyed by global conn id.
+    pub conns: DashMap<u64, Arc<ConnEntry>>,
+    /// Sum of `bytes_in` across every conn that has *closed* on this
+    /// tunnel. Live conns' bytes are added to the "active" counters
+    /// via [`Self::totals`] computed on read.
+    cumulative_in: AtomicU64,
+    cumulative_out: AtomicU64,
+    /// Lifetime conn count, including closed ones. Useful for "how
+    /// many connects have I served on this tunnel".
+    total_conns: AtomicU64,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TunnelTotals {
+    pub active_in: u64,
+    pub active_out: u64,
+    pub cumulative_in: u64,
+    pub cumulative_out: u64,
+    pub active_conns: u64,
+    pub total_conns: u64,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ClientTotals {
+    pub active_in: u64,
+    pub active_out: u64,
+    pub cumulative_in: u64,
+    pub cumulative_out: u64,
+    pub active_conns: u64,
+    pub total_conns: u64,
+}
+
+impl TunnelEntry {
+    pub fn totals(&self) -> TunnelTotals {
+        let mut active_in = 0u64;
+        let mut active_out = 0u64;
+        for c in self.conns.iter() {
+            let (i, o) = c.value().counters.snapshot();
+            active_in += i;
+            active_out += o;
+        }
+        TunnelTotals {
+            active_in,
+            active_out,
+            cumulative_in: self.cumulative_in.load(Ordering::Relaxed),
+            cumulative_out: self.cumulative_out.load(Ordering::Relaxed),
+            active_conns: self.conns.len() as u64,
+            total_conns: self.total_conns.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Live per-conn record. Each conn's `counters` is shared directly
+/// with the data-plane handler; the admin API reads it via
+/// [`TunnelCounters::snapshot`].
+#[derive(Debug)]
+pub struct ConnEntry {
+    pub id: u64,
+    pub tunnel_id: u64,
+    pub client_id: u64,
+    pub opened_at: SystemTime,
+    /// Optional human-readable peer description ("127.0.0.1:54321",
+    /// "→8.8.8.8:53", …). Origin depends on the handler that registered
+    /// the conn and is intentionally free-form for now.
+    pub peer: Option<String>,
+    pub counters: Arc<TunnelCounters>,
+}
+
+// ---------------------------------------------------------------------------
+// Disconnect history
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HistoryEntry {
+    pub client_id: u64,
+    pub remote: String,
+    pub connected_at_ms: u64,
+    pub disconnected_at_ms: u64,
+    pub reason: String,
+    pub bytes_in: u64,
+    pub bytes_out: u64,
+    pub total_conns: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Top-level state
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct ServerState {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    started_at: SystemTime,
+    listen_addr: SocketAddr,
+    next_tunnel_id: AtomicU64,
+    next_conn_id: AtomicU64,
+    clients: DashMap<u64, Arc<ClientEntry>>,
+    /// Flat global index of tunnels (alongside the per-client view in
+    /// [`ClientEntry::tunnels`]), so `/api/v1/tunnels/:id` doesn't have
+    /// to scan every client.
+    tunnels: DashMap<u64, Arc<TunnelEntry>>,
+    /// Flat global index of conns, same rationale.
+    conns: DashMap<u64, Arc<ConnEntry>>,
+    history: RwLock<VecDeque<HistoryEntry>>,
+}
+
+impl ServerState {
+    pub fn new(listen_addr: SocketAddr) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                started_at: SystemTime::now(),
+                listen_addr,
+                next_tunnel_id: AtomicU64::new(0),
+                next_conn_id: AtomicU64::new(0),
+                clients: DashMap::new(),
+                tunnels: DashMap::new(),
+                conns: DashMap::new(),
+                history: RwLock::new(VecDeque::with_capacity(HISTORY_CAPACITY)),
+            }),
+        }
+    }
+
+    pub fn started_at(&self) -> SystemTime {
+        self.inner.started_at
+    }
+
+    pub fn listen_addr(&self) -> SocketAddr {
+        self.inner.listen_addr
+    }
+
+    pub fn client_count(&self) -> usize {
+        self.inner.clients.len()
+    }
+
+    pub fn tunnel_count(&self) -> usize {
+        self.inner.tunnels.len()
+    }
+
+    pub fn conn_count(&self) -> usize {
+        self.inner.conns.len()
+    }
+
+    // -- clients ------------------------------------------------------------
+
+    pub fn register_client(
+        &self,
+        id: u64,
+        remote: SocketAddr,
+        conn: Connection,
+    ) -> Arc<ClientEntry> {
+        let entry = Arc::new(ClientEntry {
+            id,
+            remote,
+            connected_at: SystemTime::now(),
+            tunnels: DashMap::new(),
+            tunnel_index: DashMap::new(),
+            conn,
+        });
+        self.inner.clients.insert(id, entry.clone());
+        entry
+    }
+
+    pub fn deregister_client(&self, id: u64, reason: impl Into<String>) {
+        let Some((_, entry)) = self.inner.clients.remove(&id) else {
+            return;
+        };
+
+        // Roll up tunnel + conn totals before tearing them down so the
+        // [`HistoryEntry`] reflects everything that flowed.
+        let totals = entry.totals();
+
+        // Drop conns attached to this client's tunnels from the global
+        // conn index. The per-conn counter atomics are inside each
+        // `Arc<ConnEntry>` and go away with the last clone.
+        let tunnel_ids: Vec<u64> = entry.tunnels.iter().map(|t| t.value().id).collect();
+        for tunnel_id in &tunnel_ids {
+            if let Some((_, tunnel)) = self.inner.tunnels.remove(tunnel_id) {
+                for c in tunnel.conns.iter() {
+                    self.inner.conns.remove(&c.value().id);
+                }
+            }
+        }
+
+        let h = HistoryEntry {
+            client_id: entry.id,
+            remote: entry.remote.to_string(),
+            connected_at_ms: unix_ms(entry.connected_at),
+            disconnected_at_ms: unix_ms(SystemTime::now()),
+            reason: reason.into(),
+            bytes_in: totals.active_in + totals.cumulative_in,
+            bytes_out: totals.active_out + totals.cumulative_out,
+            total_conns: totals.total_conns,
+        };
+        if let Ok(mut hist) = self.inner.history.write() {
+            if hist.len() == HISTORY_CAPACITY {
+                hist.pop_front();
+            }
+            hist.push_back(h);
+        }
+    }
+
+    // -- tunnels ------------------------------------------------------------
+
+    /// Register a tunnel for `client` keyed by `request`'s spec string,
+    /// or return the existing entry if the client already declared a
+    /// matching one. This is what lets the same forward TCP remote
+    /// share a tunnel across many conns.
+    pub fn find_or_create_tunnel(
+        &self,
+        client: &ClientEntry,
+        request: &RemoteRequest,
+    ) -> Arc<TunnelEntry> {
+        let spec = request.to_string();
+        // The DashMap entry API holds the shard lock for `spec`, so
+        // two concurrent first-conns on the same forward remote
+        // serialize through here and only one creates a tunnel.
+        match client.tunnel_index.entry(spec.clone()) {
+            dashmap::mapref::entry::Entry::Occupied(o) => {
+                let tunnel_id = *o.get();
+                if let Some(t) = client.tunnels.get(&tunnel_id) {
+                    return t.value().clone();
+                }
+                // Index pointed at a tunnel that has since been
+                // removed (shouldn't happen while the client is alive,
+                // but treat it as a recreate). Fall through after
+                // dropping the stale index entry.
+                drop(o);
+            }
+            dashmap::mapref::entry::Entry::Vacant(v) => {
+                let id = self.inner.next_tunnel_id.fetch_add(1, Ordering::Relaxed) + 1;
+                let entry = Arc::new(TunnelEntry {
+                    id,
+                    client_id: client.id,
+                    direction: request.direction,
+                    kind: request.kind.clone(),
+                    spec,
+                    opened_at: SystemTime::now(),
+                    conns: DashMap::new(),
+                    cumulative_in: AtomicU64::new(0),
+                    cumulative_out: AtomicU64::new(0),
+                    total_conns: AtomicU64::new(0),
+                });
+                client.tunnels.insert(id, entry.clone());
+                self.inner.tunnels.insert(id, entry.clone());
+                v.insert(id);
+                return entry;
+            }
+        }
+        // Stale-index recovery path: fall back to the un-deduped
+        // create. Exceedingly rare so we don't bother optimising it.
+        let id = self.inner.next_tunnel_id.fetch_add(1, Ordering::Relaxed) + 1;
+        let entry = Arc::new(TunnelEntry {
+            id,
+            client_id: client.id,
+            direction: request.direction,
+            kind: request.kind.clone(),
+            spec: request.to_string(),
+            opened_at: SystemTime::now(),
+            conns: DashMap::new(),
+            cumulative_in: AtomicU64::new(0),
+            cumulative_out: AtomicU64::new(0),
+            total_conns: AtomicU64::new(0),
+        });
+        client.tunnels.insert(id, entry.clone());
+        self.inner.tunnels.insert(id, entry.clone());
+        client.tunnel_index.insert(request.to_string(), id);
+        entry
+    }
+
+    pub fn tunnel(&self, id: u64) -> Option<Arc<TunnelEntry>> {
+        self.inner.tunnels.get(&id).map(|e| e.value().clone())
+    }
+
+    pub fn tunnels_snapshot(&self) -> Vec<Arc<TunnelEntry>> {
+        self.inner
+            .tunnels
+            .iter()
+            .map(|e| e.value().clone())
+            .collect()
+    }
+
+    // -- conns --------------------------------------------------------------
+
+    /// Register a fresh conn against `tunnel` and return a
+    /// [`ConnGuard`] whose `Drop` impl will deregister it (rolling its
+    /// byte counters into the tunnel's cumulative totals). The guard
+    /// exposes [`ConnGuard::counters`] which is what the data-plane
+    /// handler should pass to [`crate::common::tcp::tunnel_tcp_stream`]
+    /// / udp / socks.
+    pub fn register_conn(&self, tunnel: &Arc<TunnelEntry>, peer: Option<String>) -> ConnGuard {
+        let id = self.inner.next_conn_id.fetch_add(1, Ordering::Relaxed) + 1;
+        let counters = TunnelCounters::new();
+        let entry = Arc::new(ConnEntry {
+            id,
+            tunnel_id: tunnel.id,
+            client_id: tunnel.client_id,
+            opened_at: SystemTime::now(),
+            peer,
+            counters: counters.clone(),
+        });
+        tunnel.conns.insert(id, entry.clone());
+        self.inner.conns.insert(id, entry.clone());
+        tunnel.total_conns.fetch_add(1, Ordering::Relaxed);
+        ConnGuard {
+            state: self.clone(),
+            tunnel: tunnel.clone(),
+            conn: entry,
+        }
+    }
+
+    pub fn conn(&self, id: u64) -> Option<Arc<ConnEntry>> {
+        self.inner.conns.get(&id).map(|e| e.value().clone())
+    }
+
+    pub fn conns_snapshot(&self) -> Vec<Arc<ConnEntry>> {
+        self.inner.conns.iter().map(|e| e.value().clone()).collect()
+    }
+
+    /// Internal: called by [`ConnGuard::drop`] to fold a conn's final
+    /// byte totals into its tunnel's cumulative counters and remove it
+    /// from both indices.
+    fn close_conn(&self, tunnel: &Arc<TunnelEntry>, conn: &Arc<ConnEntry>) {
+        let (i, o) = conn.counters.snapshot();
+        tunnel.cumulative_in.fetch_add(i, Ordering::Relaxed);
+        tunnel.cumulative_out.fetch_add(o, Ordering::Relaxed);
+        tunnel.conns.remove(&conn.id);
+        self.inner.conns.remove(&conn.id);
+    }
+
+    // -- clients ------------------------------------------------------------
+
+    pub fn clients_snapshot(&self) -> Vec<Arc<ClientEntry>> {
+        self.inner
+            .clients
+            .iter()
+            .map(|e| e.value().clone())
+            .collect()
+    }
+
+    pub fn client(&self, id: u64) -> Option<Arc<ClientEntry>> {
+        self.inner.clients.get(&id).map(|e| e.value().clone())
+    }
+
+    pub fn history_snapshot(&self, limit: usize) -> Vec<HistoryEntry> {
+        let Ok(hist) = self.inner.history.read() else {
+            return Vec::new();
+        };
+        let take = limit.min(hist.len());
+        hist.iter().rev().take(take).cloned().collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Drop-guard so per-conn bookkeeping is removed on every exit path
+// (success, error, panic, or `JoinSet::shutdown` on disconnect).
+// ---------------------------------------------------------------------------
+
+pub struct ConnGuard {
+    state: ServerState,
+    tunnel: Arc<TunnelEntry>,
+    conn: Arc<ConnEntry>,
+}
+
+impl ConnGuard {
+    /// The shared atomics the data-plane handler should bump.
+    pub fn counters(&self) -> Arc<TunnelCounters> {
+        self.conn.counters.clone()
+    }
+}
+
+impl Drop for ConnGuard {
+    fn drop(&mut self) {
+        self.state.close_conn(&self.tunnel, &self.conn);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `TunnelHandle` — passed into reverse-tunnel handlers (which open many
+// conns over their lifetime, e.g. one per accept on a reverse TCP
+// listener) so they can register conns without depending on
+// `ServerState` directly.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct TunnelHandle {
+    state: ServerState,
+    tunnel: Arc<TunnelEntry>,
+}
+
+impl TunnelHandle {
+    pub fn new(state: ServerState, tunnel: Arc<TunnelEntry>) -> Self {
+        Self { state, tunnel }
+    }
+
+    pub fn open_conn(&self, peer: Option<String>) -> ConnGuard {
+        self.state.register_conn(&self.tunnel, peer)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire-format DTOs the admin HTTP layer serializes.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct ServerInfoDto {
+    pub version: &'static str,
+    pub listen_addr: String,
+    pub started_at_ms: u64,
+    pub uptime_ms: u64,
+    pub client_count: usize,
+    pub tunnel_count: usize,
+    pub active_conn_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ClientSummaryDto {
+    pub id: u64,
+    pub remote: String,
+    pub connected_at_ms: u64,
+    pub tunnel_count: usize,
+    pub active_conn_count: u64,
+    pub total_conns: u64,
+    pub bytes_in: u64,
+    pub bytes_out: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ClientDetailDto {
+    #[serde(flatten)]
+    pub summary: ClientSummaryDto,
+    pub tunnels: Vec<TunnelDto>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TunnelDto {
+    pub id: u64,
+    pub client_id: u64,
+    pub direction: &'static str,
+    pub kind: &'static str,
+    pub spec: String,
+    pub opened_at_ms: u64,
+    pub active_conn_count: u64,
+    pub total_conns: u64,
+    pub active_bytes_in: u64,
+    pub active_bytes_out: u64,
+    pub bytes_in: u64,
+    pub bytes_out: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TunnelDetailDto {
+    #[serde(flatten)]
+    pub summary: TunnelDto,
+    pub conns: Vec<ConnDto>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConnDto {
+    pub id: u64,
+    pub tunnel_id: u64,
+    pub client_id: u64,
+    pub opened_at_ms: u64,
+    pub peer: Option<String>,
+    pub bytes_in: u64,
+    pub bytes_out: u64,
+}
+
+impl ClientSummaryDto {
+    pub fn from_entry(entry: &ClientEntry) -> Self {
+        let t = entry.totals();
+        Self {
+            id: entry.id,
+            remote: entry.remote.to_string(),
+            connected_at_ms: unix_ms(entry.connected_at),
+            tunnel_count: entry.tunnels.len(),
+            active_conn_count: t.active_conns,
+            total_conns: t.total_conns,
+            bytes_in: t.active_in + t.cumulative_in,
+            bytes_out: t.active_out + t.cumulative_out,
+        }
+    }
+}
+
+impl TunnelDto {
+    pub fn from_entry(entry: &TunnelEntry) -> Self {
+        let t = entry.totals();
+        Self {
+            id: entry.id,
+            client_id: entry.client_id,
+            direction: match entry.direction {
+                Direction::Forward => "forward",
+                Direction::Reverse => "reverse",
+            },
+            kind: match entry.kind {
+                RemoteKind::Tcp { .. } => "tcp",
+                RemoteKind::Udp { .. } => "udp",
+                RemoteKind::Socks5 { .. } => "socks5",
+            },
+            spec: entry.spec.clone(),
+            opened_at_ms: unix_ms(entry.opened_at),
+            active_conn_count: t.active_conns,
+            total_conns: t.total_conns,
+            active_bytes_in: t.active_in,
+            active_bytes_out: t.active_out,
+            bytes_in: t.active_in + t.cumulative_in,
+            bytes_out: t.active_out + t.cumulative_out,
+        }
+    }
+}
+
+impl ConnDto {
+    pub fn from_entry(entry: &ConnEntry) -> Self {
+        let (i, o) = entry.counters.snapshot();
+        Self {
+            id: entry.id,
+            tunnel_id: entry.tunnel_id,
+            client_id: entry.client_id,
+            opened_at_ms: unix_ms(entry.opened_at),
+            peer: entry.peer.clone(),
+            bytes_in: i,
+            bytes_out: o,
+        }
+    }
+}
+
+pub fn server_info(state: &ServerState) -> ServerInfoDto {
+    let now = SystemTime::now();
+    let uptime_ms = now
+        .duration_since(state.started_at())
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    ServerInfoDto {
+        version: env!("CARGO_PKG_VERSION"),
+        listen_addr: state.listen_addr().to_string(),
+        started_at_ms: unix_ms(state.started_at()),
+        uptime_ms,
+        client_count: state.client_count(),
+        tunnel_count: state.tunnel_count(),
+        active_conn_count: state.conn_count(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn history_is_bounded_and_recent_first() {
+        let state = ServerState::new("127.0.0.1:0".parse().unwrap());
+        for i in 0..(HISTORY_CAPACITY + 5) {
+            let mut hist = state.inner.history.write().unwrap();
+            if hist.len() == HISTORY_CAPACITY {
+                hist.pop_front();
+            }
+            hist.push_back(HistoryEntry {
+                client_id: i as u64,
+                remote: format!("127.0.0.1:{i}"),
+                connected_at_ms: 0,
+                disconnected_at_ms: 0,
+                reason: "ok".into(),
+                bytes_in: 0,
+                bytes_out: 0,
+                total_conns: 0,
+            });
+        }
+        let snap = state.history_snapshot(10);
+        assert_eq!(snap.len(), 10);
+        assert!(snap[0].client_id > snap.last().unwrap().client_id);
+    }
+}

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -20,7 +20,8 @@
 //!
 //! Lifecycle hooks (driven from [`super`]):
 //! * client connect → [`ServerState::register_client`]
-//! * control-plane handshake → [`ServerState::find_or_create_tunnel`]
+//! * session hello → [`ServerState::register_tunnels`] pre-allocates one
+//!   [`TunnelEntry`] per declared remote in a single batch
 //! * data-plane stream / accepted-conn → [`ServerState::register_conn`]
 //!   (dropped via [`ConnGuard`])
 //! * client disconnect → [`ServerState::deregister_client`] which fans
@@ -60,17 +61,13 @@ pub struct ClientEntry {
     pub id: u64,
     pub remote: SocketAddr,
     pub connected_at: SystemTime,
-    /// Tunnels currently registered against this client. Deduped by
-    /// the spec string, so reconnects of the same forward tunnel share
-    /// an entry. Held as `Arc`s so the admin routes can grab a snapshot
-    /// without holding the shard lock across JSON serialization.
+    /// Tunnels registered against this client by the session hello.
+    /// Pre-allocated once, in a single [`ServerState::register_tunnels`]
+    /// call, so deduplication is unnecessary — each `--remote` flag on
+    /// the client CLI maps to exactly one entry. Held as `Arc`s so the
+    /// admin routes can grab a snapshot without holding the shard lock
+    /// across JSON serialization.
     pub tunnels: DashMap<u64, Arc<TunnelEntry>>,
-    /// Auxiliary index `spec → tunnel_id` so [`ServerState::find_or_create_tunnel`]
-    /// can dedupe atomically via `DashMap::entry`. Without this, two
-    /// concurrent first-conns on the same forward TCP remote both
-    /// observe an empty `tunnels` map and each create a separate
-    /// tunnel entry.
-    tunnel_index: DashMap<String, u64>,
     /// Live QUIC handle. Kept around for phase-2 write endpoints
     /// (`DELETE /clients/:id` → `connection.close(...)`); no read path
     /// dereferences it today.
@@ -265,7 +262,6 @@ impl ServerState {
             remote,
             connected_at: SystemTime::now(),
             tunnels: DashMap::new(),
-            tunnel_index: DashMap::new(),
             conn,
         });
         self.inner.clients.insert(id, entry.clone());
@@ -313,39 +309,27 @@ impl ServerState {
 
     // -- tunnels ------------------------------------------------------------
 
-    /// Register a tunnel for `client` keyed by `request`'s spec string,
-    /// or return the existing entry if the client already declared a
-    /// matching one. This is what lets the same forward TCP remote
-    /// share a tunnel across many conns.
-    pub fn find_or_create_tunnel(
+    /// Bulk-register every tunnel declared in the client's session
+    /// hello, returning the freshly minted entries in the same order
+    /// as `requests`. Allocates a fresh `tunnel_id` per declaration —
+    /// duplicate specs in a single hello produce two separate
+    /// tunnels (the wire protocol no longer needs dedup, since
+    /// forward conns no longer re-send a `RemoteRequest` per stream).
+    pub fn register_tunnels(
         &self,
         client: &ClientEntry,
-        request: &RemoteRequest,
-    ) -> Arc<TunnelEntry> {
-        let spec = request.to_string();
-        // The DashMap entry API holds the shard lock for `spec`, so
-        // two concurrent first-conns on the same forward remote
-        // serialize through here and only one creates a tunnel.
-        match client.tunnel_index.entry(spec.clone()) {
-            dashmap::mapref::entry::Entry::Occupied(o) => {
-                let tunnel_id = *o.get();
-                if let Some(t) = client.tunnels.get(&tunnel_id) {
-                    return t.value().clone();
-                }
-                // Index pointed at a tunnel that has since been
-                // removed (shouldn't happen while the client is alive,
-                // but treat it as a recreate). Fall through after
-                // dropping the stale index entry.
-                drop(o);
-            }
-            dashmap::mapref::entry::Entry::Vacant(v) => {
+        requests: &[RemoteRequest],
+    ) -> Vec<Arc<TunnelEntry>> {
+        requests
+            .iter()
+            .map(|req| {
                 let id = self.inner.next_tunnel_id.fetch_add(1, Ordering::Relaxed) + 1;
                 let entry = Arc::new(TunnelEntry {
                     id,
                     client_id: client.id,
-                    direction: request.direction,
-                    kind: request.kind.clone(),
-                    spec,
+                    direction: req.direction,
+                    kind: req.kind.clone(),
+                    spec: req.to_string(),
                     opened_at: SystemTime::now(),
                     conns: DashMap::new(),
                     cumulative_in: AtomicU64::new(0),
@@ -354,29 +338,9 @@ impl ServerState {
                 });
                 client.tunnels.insert(id, entry.clone());
                 self.inner.tunnels.insert(id, entry.clone());
-                v.insert(id);
-                return entry;
-            }
-        }
-        // Stale-index recovery path: fall back to the un-deduped
-        // create. Exceedingly rare so we don't bother optimising it.
-        let id = self.inner.next_tunnel_id.fetch_add(1, Ordering::Relaxed) + 1;
-        let entry = Arc::new(TunnelEntry {
-            id,
-            client_id: client.id,
-            direction: request.direction,
-            kind: request.kind.clone(),
-            spec: request.to_string(),
-            opened_at: SystemTime::now(),
-            conns: DashMap::new(),
-            cumulative_in: AtomicU64::new(0),
-            cumulative_out: AtomicU64::new(0),
-            total_conns: AtomicU64::new(0),
-        });
-        client.tunnels.insert(id, entry.clone());
-        self.inner.tunnels.insert(id, entry.clone());
-        client.tunnel_index.insert(request.to_string(), id);
-        entry
+                entry
+            })
+            .collect()
     }
 
     pub fn tunnel(&self, id: u64) -> Option<Arc<TunnelEntry>> {
@@ -477,6 +441,10 @@ impl ConnGuard {
     /// The shared atomics the data-plane handler should bump.
     pub fn counters(&self) -> Arc<TunnelCounters> {
         self.conn.counters.clone()
+    }
+
+    pub fn id(&self) -> u64 {
+        self.conn.id
     }
 }
 

--- a/tests/admin.rs
+++ b/tests/admin.rs
@@ -1,0 +1,314 @@
+//! End-to-end test for the read-only admin API.
+//!
+//! Spins up a real server + client pair on localhost (matching the
+//! existing `tests/tunnels.rs` style), shovels bytes through a forward
+//! TCP tunnel, and then exercises every `GET /api/v1/...` endpoint over
+//! the unix socket to verify the JSON shape, byte counters, and history
+//! recording.
+
+mod common;
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use rusnel::common::remote::RemoteRequest;
+use rusnel::common::tls::{ClientTlsConfig, ServerTlsConfig};
+use rusnel::ctl;
+use rusnel::{ClientConfig, ReconnectConfig, ServerConfig, ServerEndpoint};
+use serde_json::Value;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+use common::{get_available_port, init_crypto, STARTUP_DELAY};
+
+/// Build a short unix-socket path under `/tmp`. macOS's `sun_path` is
+/// only ~104 bytes and `$TMPDIR` is too long, so we route around it.
+fn admin_sock_path(label: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    PathBuf::from(format!(
+        "/tmp/rusnel-it-{}-{}-{}.sock",
+        label,
+        std::process::id(),
+        nanos
+    ))
+}
+
+#[tokio::test]
+async fn admin_api_lifecycle() {
+    init_crypto();
+
+    let server_port = get_available_port();
+    let upstream_port = get_available_port();
+    let local_port = get_available_port();
+    let socket_path = admin_sock_path("lifecycle");
+
+    // Upstream echo TCP server. Reflects whatever the client writes so we
+    // can assert bytes_in/bytes_out independently.
+    let upstream_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), upstream_port);
+    let upstream_listener = TcpListener::bind(upstream_addr).await.unwrap();
+    let upstream_handle = tokio::spawn(async move {
+        loop {
+            let (mut sock, _) = match upstream_listener.accept().await {
+                Ok(v) => v,
+                Err(_) => return,
+            };
+            tokio::spawn(async move {
+                let mut buf = [0u8; 1024];
+                while let Ok(n) = sock.read(&mut buf).await {
+                    if n == 0 {
+                        return;
+                    }
+                    if sock.write_all(&buf[..n]).await.is_err() {
+                        return;
+                    }
+                }
+            });
+        }
+    });
+
+    // Bring up the rusnel server with admin enabled.
+    let server_config = ServerConfig {
+        host: IpAddr::V4(Ipv4Addr::LOCALHOST),
+        port: server_port,
+        allow_reverse: true,
+        allow_socks: true,
+        tls: ServerTlsConfig::Insecure,
+        congestion: Default::default(),
+        max_connections: None,
+        admin_socket: Some(socket_path.clone()),
+    };
+    let server_handle = tokio::spawn(async move {
+        let _ = rusnel::server::run_async(server_config).await;
+    });
+    tokio::time::sleep(STARTUP_DELAY).await;
+
+    // The socket file should now exist with mode 0600.
+    let mode = std::fs::metadata(&socket_path)
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(mode, 0o600, "expected 0600, got {mode:o}");
+
+    // Bring up the client with one forward TCP tunnel pointing at the
+    // upstream echo server.
+    let remote_str = format!("127.0.0.1:{local_port}:127.0.0.1:{upstream_port}");
+    let remote: RemoteRequest = remote_str.parse().expect("parse remote spec");
+    let remote_display = remote.to_string();
+    let client_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), server_port);
+    let client_config = ClientConfig {
+        server: ServerEndpoint {
+            addrs: vec![client_addr],
+            host: client_addr.ip().to_string(),
+        },
+        remotes: vec![remote.clone()],
+        tls: ClientTlsConfig::Insecure,
+        congestion: Default::default(),
+        reconnect: ReconnectConfig::default(),
+        proxy: None,
+    };
+    let client_handle = tokio::spawn(async move {
+        let _ = rusnel::client::run_async(client_config).await;
+    });
+    tokio::time::sleep(STARTUP_DELAY).await;
+
+    // /api/v1/server: version + listen addr present.
+    let server_info = ctl::get(&socket_path, "/api/v1/server").await.unwrap();
+    assert!(server_info["version"].as_str().is_some());
+    assert!(server_info["listen_addr"]
+        .as_str()
+        .unwrap()
+        .ends_with(&server_port.to_string()));
+
+    // /api/v1/clients: exactly one entry.
+    let clients = await_clients(&socket_path, 1).await;
+    let client_id = clients[0]["id"].as_u64().expect("client id is u64");
+    assert!(clients[0]["remote"].as_str().unwrap().contains("127.0.0.1"));
+
+    // Forward TCP tunnels register on the server only when the client
+    // opens a bi-stream — i.e. when a local TCP connection arrives. So
+    // connect first, then exercise the tunnels endpoint.
+    let mut conn = TcpStream::connect(("127.0.0.1", local_port)).await.unwrap();
+    let payload = b"hello rusnel admin api\n";
+    conn.write_all(payload).await.unwrap();
+    let mut buf = vec![0u8; payload.len()];
+    conn.read_exact(&mut buf).await.unwrap();
+    assert_eq!(&buf, payload);
+
+    // /api/v1/tunnels: one tunnel, spec matches.
+    let tunnels = await_tunnels(&socket_path, 1).await;
+    assert_eq!(tunnels[0]["client_id"].as_u64().unwrap(), client_id);
+    assert_eq!(tunnels[0]["spec"].as_str().unwrap(), remote_display);
+    let tunnel_id = tunnels[0]["id"].as_u64().unwrap();
+
+    // Tunnel-vs-conn distinction: a *single* tunnel can carry many
+    // conns. Open a second concurrent connection through the same
+    // local port and verify the tunnel count stays at 1 while the
+    // conn count grows to 2.
+    let mut conn2 = TcpStream::connect(("127.0.0.1", local_port)).await.unwrap();
+    conn2.write_all(b"second\n").await.unwrap();
+    let mut buf2 = vec![0u8; 7];
+    conn2.read_exact(&mut buf2).await.unwrap();
+
+    let mut active_conns = 0u64;
+    for _ in 0..50 {
+        let detail = ctl::get(&socket_path, &format!("/api/v1/tunnels/{tunnel_id}"))
+            .await
+            .unwrap();
+        active_conns = detail["active_conn_count"].as_u64().unwrap_or(0);
+        if active_conns >= 2 {
+            assert_eq!(
+                detail["conns"].as_array().map(|a| a.len()).unwrap_or(0),
+                active_conns as usize,
+                "embedded conns array should match active_conn_count"
+            );
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(40)).await;
+    }
+    assert!(
+        active_conns >= 2,
+        "expected at least 2 active conns on the tunnel, got {active_conns}"
+    );
+    let tunnel_list_again = ctl::get(&socket_path, "/api/v1/tunnels")
+        .await
+        .unwrap()
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(
+        tunnel_list_again.len(),
+        1,
+        "tunnels are deduped by spec — second connection must not add a tunnel"
+    );
+
+    // /api/v1/conns: global conn list reflects the tunnel's
+    // active conns.
+    let conns_global = ctl::get(&socket_path, "/api/v1/conns")
+        .await
+        .unwrap()
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        conns_global.len() >= 2,
+        "global /conns should see >=2 active conns"
+    );
+    for s in &conns_global {
+        assert_eq!(s["tunnel_id"].as_u64().unwrap(), tunnel_id);
+        assert_eq!(s["client_id"].as_u64().unwrap(), client_id);
+    }
+
+    // /api/v1/clients/:id/conns: scoped query returns the same.
+    let client_conns = ctl::get(&socket_path, &format!("/api/v1/clients/{client_id}/conns"))
+        .await
+        .unwrap()
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(client_conns.len() >= 2);
+
+    // Drop the second connection — its conn should clear, but the
+    // tunnel sticks around with cumulative counters and total_conns
+    // recording it ever existed.
+    drop(conn2);
+    let mut total_conns = 0u64;
+    for _ in 0..50 {
+        let detail = ctl::get(&socket_path, &format!("/api/v1/tunnels/{tunnel_id}"))
+            .await
+            .unwrap();
+        total_conns = detail["total_conns"].as_u64().unwrap_or(0);
+        let active = detail["active_conn_count"].as_u64().unwrap_or(0);
+        if total_conns >= 2 && active < active_conns {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(40)).await;
+    }
+    assert!(
+        total_conns >= 2,
+        "tunnel.total_conns should record closed conns; got {total_conns}"
+    );
+
+    // Counters update lazily as data flows; poll a few times.
+    let mut bin = 0u64;
+    let mut bout = 0u64;
+    for _ in 0..50 {
+        let tunnels = ctl::get(&socket_path, "/api/v1/tunnels")
+            .await
+            .unwrap()
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        if let Some(t) = tunnels.first() {
+            bin = t["bytes_in"].as_u64().unwrap_or(0);
+            bout = t["bytes_out"].as_u64().unwrap_or(0);
+            if bin > 0 && bout > 0 {
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(40)).await;
+    }
+    assert!(bin > 0, "expected bytes_in > 0, got {bin}");
+    assert!(bout > 0, "expected bytes_out > 0, got {bout}");
+
+    // /api/v1/clients/:id detail returns the same tunnel embedded.
+    let detail = ctl::get(&socket_path, &format!("/api/v1/clients/{client_id}"))
+        .await
+        .unwrap();
+    let detail_tunnels = detail["tunnels"].as_array().unwrap();
+    assert_eq!(detail_tunnels.len(), 1);
+    assert_eq!(detail_tunnels[0]["spec"].as_str().unwrap(), remote_display);
+
+    // Unknown client → 404.
+    let err = ctl::get(&socket_path, "/api/v1/clients/999999")
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("404"), "expected 404 in error, got: {err}");
+
+    // /api/v1/history initially returns an empty array (we haven't
+    // disconnected anyone yet — the disconnect → history-push path is
+    // covered by a unit test in `src/server/state.rs` because the QUIC
+    // idle-timeout-driven disconnect detection is too slow to exercise
+    // reliably in an end-to-end test).
+    let history = ctl::get(&socket_path, "/api/v1/history").await.unwrap();
+    assert!(history.is_array(), "history should be a JSON array");
+
+    drop(conn);
+    client_handle.abort();
+    server_handle.abort();
+    upstream_handle.abort();
+    let _ = std::fs::remove_file(&socket_path);
+}
+
+/// Poll `/api/v1/clients` until at least `n` entries appear or we time out.
+async fn await_clients(socket_path: &std::path::Path, n: usize) -> Vec<Value> {
+    for _ in 0..50 {
+        let v = ctl::get(socket_path, "/api/v1/clients").await.unwrap();
+        if let Some(arr) = v.as_array() {
+            if arr.len() >= n {
+                return arr.clone();
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(40)).await;
+    }
+    panic!("timed out waiting for {n} client(s)");
+}
+
+async fn await_tunnels(socket_path: &std::path::Path, n: usize) -> Vec<Value> {
+    for _ in 0..50 {
+        let v = ctl::get(socket_path, "/api/v1/tunnels").await.unwrap();
+        if let Some(arr) = v.as_array() {
+            if arr.len() >= n {
+                return arr.clone();
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(40)).await;
+    }
+    panic!("timed out waiting for {n} tunnel(s)");
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -102,6 +102,7 @@ pub fn server_config_with_tls(
         tls,
         congestion: Default::default(),
         max_connections: None,
+        admin_socket: None,
     }
 }
 

--- a/tests/disconnect_cleanup.rs
+++ b/tests/disconnect_cleanup.rs
@@ -16,10 +16,9 @@ use std::time::Duration;
 use common::{get_available_port, init_crypto, server_config, STARTUP_DELAY};
 use quinn::VarInt;
 use rusnel::common::quic::{create_client_endpoint, Congestion};
-use rusnel::common::remote::RemoteRequest;
+use rusnel::common::remote::{RemoteRequest, SessionHello};
 use rusnel::common::tls::ClientTlsConfig;
-use rusnel::common::tunnel::client_send_remote_request;
-use tokio::io::AsyncWriteExt;
+use rusnel::common::tunnel::client_send_session_hello;
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 
@@ -96,11 +95,18 @@ async fn test_server_releases_reverse_listener_on_client_disconnect() {
             "R:127.0.0.1:{reverse_listen_port}:127.0.0.1:{reverse_target_port}"
         ))
         .unwrap();
+        // Send a session hello carrying just this one reverse remote.
+        // The post-0.8 wire protocol no longer accepts a per-stream
+        // `RemoteRequest`; tunnels are declared up front and the
+        // server spawns the reverse listener on receipt of the
+        // hello reply.
         let (mut send, mut recv) = connection.open_bi().await.unwrap();
-        client_send_remote_request(&remote, &mut send, &mut recv)
+        let hello = SessionHello {
+            remotes: vec![remote],
+        };
+        let _ = client_send_session_hello(&hello, &mut send, &mut recv)
             .await
             .unwrap();
-        send.shutdown().await.unwrap();
 
         let bound = wait_until(Duration::from_secs(10), || async {
             !port_is_free(reverse_listen_port).await

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -65,64 +65,40 @@ async fn test_reverse_rejected_when_not_allowed() {
     .expect("test_reverse_rejected_when_not_allowed timed out");
 }
 
-/// Forward `socks` requires `--allow-socks`. Without it, the client's local
-/// SOCKS5 listener still binds (the SOCKS handshake is purely client-side),
-/// but the per-CONNECT dynamic remote — which carries `from_socks=true` on
-/// the wire — must be rejected by the server, so any actual CONNECT through
-/// the SOCKS proxy fails to reach the target.
+/// Forward `socks` requires `--allow-socks`. Without it, the server
+/// rejects the session at hello time (the post-0.8 wire protocol
+/// validates every declared remote in one batch up front), so the
+/// client never gets past reconnect — its local SOCKS listener
+/// never binds.
 #[tokio::test]
 async fn test_forward_socks_rejected_when_not_allowed() {
     timeout(TEST_TIMEOUT, async {
         let server_port = get_available_port();
         let socks_port = get_available_port();
-        let target_port = get_available_port();
-
-        // Bind a target listener so the only reason a CONNECT could fail is
-        // the server-side ACL.
-        let _target = TcpListener::bind(format!("127.0.0.1:{target_port}"))
-            .await
-            .unwrap();
 
         let remote = RemoteRequest::from_str(&format!("127.0.0.1:{socks_port}:socks")).unwrap();
 
-        // allow_reverse=false, allow_socks=false — forward `socks` must be
-        // rejected by the server's `--allow-socks` gate even though the
-        // client-side listener comes up fine.
+        // allow_reverse=false, allow_socks=false — the hello must be
+        // rejected, leaving the client looping on reconnect with no
+        // local SOCKS listener bound.
         let _env = start_tunnel_with_flags(server_port, false, false, vec![remote]).await;
 
-        // SOCKS5 greeting + CONNECT to the target. The greeting itself is
-        // local to the client and should always succeed; the CONNECT
-        // attempts to open a server-side stream and must fail (the server
-        // closes it, surfacing as either a non-success SOCKS reply or an
-        // EOF on the SOCKS TCP connection).
-        let mut conn = TcpStream::connect(format!("127.0.0.1:{socks_port}"))
-            .await
-            .expect("connect to local SOCKS listener");
-        conn.write_all(&[0x05, 0x01, 0x00]).await.unwrap();
-        let mut greet = [0u8; 2];
-        conn.read_exact(&mut greet).await.unwrap();
-        assert_eq!(greet, [0x05, 0x00]);
-
-        let mut req = vec![0x05, 0x01, 0x00, 0x01, 127, 0, 0, 1];
-        req.extend_from_slice(&target_port.to_be_bytes());
-        conn.write_all(&req).await.unwrap();
-
-        // Read whatever the SOCKS server sends back (or EOF). A successful
-        // CONNECT would reply with `[0x05, 0x00, ...]` (10 bytes for IPv4
-        // BND). Anything else means the server-side gate fired.
-        let mut reply = [0u8; 10];
-        match conn.read_exact(&mut reply).await {
-            Err(_) => { /* EOF before full reply: server-side stream closed. */ }
-            Ok(_) => assert_ne!(
-                reply[1], 0x00,
-                "expected SOCKS5 CONNECT to fail, but got success reply"
+        // Give the client a chance to settle into the reject loop, then
+        // verify the local SOCKS port is still unbindable-from-our-side
+        // (i.e. nothing is listening on it).
+        sleep(Duration::from_millis(300)).await;
+        let connect_res = timeout(
+            Duration::from_secs(2),
+            TcpStream::connect(format!("127.0.0.1:{socks_port}")),
+        )
+        .await;
+        match connect_res {
+            Ok(Ok(_)) => panic!(
+                "expected local SOCKS listener on port {socks_port} to never bind, but it accepted a connection"
             ),
+            Ok(Err(_)) => { /* expected: connection refused */ }
+            Err(_) => panic!("connect attempt unexpectedly hung"),
         }
-
-        // And the target listener must NOT have seen an inbound connection.
-        // We give the test a brief settling window then assert no accept
-        // happens within a short timeout.
-        sleep(Duration::from_millis(200)).await;
     })
     .await
     .expect("test_forward_socks_rejected_when_not_allowed timed out");

--- a/tests/reconnect.rs
+++ b/tests/reconnect.rs
@@ -80,19 +80,7 @@ async fn spawn_server(server_port: u16) -> ServerHandle {
                             Ok(c) => c,
                             Err(e) => { info!("incoming failed: {e}"); return; }
                         };
-                        // Run the same per-connection accept loop the real
-                        // server uses by handing each bi-stream off to the
-                        // public tunnel handler. We only need the data plane
-                        // to work end-to-end; using the library's own server
-                        // mod would require exposing more internals.
-                        loop {
-                            let stream = conn.accept_bi().await;
-                            let (send, recv) = match stream {
-                                Ok(s) => s,
-                                Err(_) => return,
-                            };
-                            tokio::spawn(handle_test_stream(conn.clone(), send, recv));
-                        }
+                        run_test_session(conn).await;
                     });
                 }
             }
@@ -109,25 +97,99 @@ async fn spawn_server(server_port: u16) -> ServerHandle {
     }
 }
 
-/// Minimal server-side stream handler that re-implements the forward-TCP path
-/// from `server::handle_remote_stream`. Using only public APIs keeps this test
-/// independent of internal layout changes.
-async fn handle_test_stream(
-    _conn: Connection,
-    mut send: quinn::SendStream,
-    mut recv: quinn::RecvStream,
-) {
+/// Minimal server stub used to exercise the client's reconnect logic.
+///
+/// Implements just enough of the v0.8 wire protocol — one
+/// [`SessionHello`] on the first bi-stream, then [`OpenConn`] on every
+/// subsequent one — to drive a forward TCP tunnel. Each accepted QUIC
+/// connection is processed by [`run_test_session`].
+async fn run_test_session(connection: Connection) {
+    use rusnel::common::remote::{
+        Direction, OpenConnResponse, RemoteKind, RemoteRequest, SessionHelloResponse,
+    };
     use rusnel::common::tcp::tunnel_tcp_server;
-    use rusnel::common::tunnel::server_receive_remote_request;
-    let request = match server_receive_remote_request(&mut send, &mut recv, false, false).await {
-        Ok(r) => r,
+    use rusnel::common::tunnel::{
+        receive_open_conn, reply_open_conn, server_receive_session_hello,
+        server_reply_session_hello,
+    };
+
+    // Session hello: read declarations, allocate fake tunnel ids, and
+    // remember each forward TCP target so OpenConn frames can be
+    // dispatched without re-parsing the original spec.
+    let (mut hello_send, mut hello_recv) = match connection.accept_bi().await {
+        Ok(s) => s,
         Err(e) => {
-            info!("control handshake failed: {e}");
+            info!("hello accept failed: {e}");
             return;
         }
     };
-    if let Err(e) = tunnel_tcp_server(recv, send, request, None).await {
-        info!("tunnel ended: {e}");
+    let hello = match server_receive_session_hello(&mut hello_recv).await {
+        Ok(h) => h,
+        Err(e) => {
+            info!("hello read failed: {e}");
+            return;
+        }
+    };
+    let mut tunnels: std::collections::HashMap<u64, RemoteRequest> =
+        std::collections::HashMap::new();
+    let mut tunnel_ids: Vec<u64> = Vec::with_capacity(hello.remotes.len());
+    for (i, r) in hello.remotes.iter().enumerate() {
+        let id = (i as u64) + 1;
+        tunnel_ids.push(id);
+        tunnels.insert(id, r.clone());
+    }
+    if let Err(e) =
+        server_reply_session_hello(&mut hello_send, &SessionHelloResponse::Ok { tunnel_ids }).await
+    {
+        info!("hello reply failed: {e}");
+        return;
+    }
+
+    // Per-conn loop.
+    loop {
+        let stream = match connection.accept_bi().await {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let tunnels = tunnels.clone();
+        tokio::spawn(async move {
+            let (mut send, mut recv) = stream;
+            let open = match receive_open_conn(&mut recv).await {
+                Ok(o) => o,
+                Err(e) => {
+                    info!("open_conn read failed: {e}");
+                    return;
+                }
+            };
+            let parent = match tunnels.get(&open.tunnel_id) {
+                Some(p) => p.clone(),
+                None => {
+                    let _ = reply_open_conn(
+                        &mut send,
+                        &OpenConnResponse::Failed("unknown tunnel".into()),
+                    )
+                    .await;
+                    return;
+                }
+            };
+            if reply_open_conn(&mut send, &OpenConnResponse::Ok)
+                .await
+                .is_err()
+            {
+                return;
+            }
+            // Only forward TCP is exercised by this test stub.
+            let req = match parent.kind {
+                RemoteKind::Tcp { local, remote } => RemoteRequest {
+                    direction: Direction::Forward,
+                    kind: RemoteKind::Tcp { local, remote },
+                },
+                _ => return,
+            };
+            if let Err(e) = tunnel_tcp_server(recv, send, req, None).await {
+                info!("tunnel ended: {e}");
+            }
+        });
     }
 }
 

--- a/tests/reconnect.rs
+++ b/tests/reconnect.rs
@@ -126,7 +126,7 @@ async fn handle_test_stream(
             return;
         }
     };
-    if let Err(e) = tunnel_tcp_server(recv, send, request).await {
+    if let Err(e) = tunnel_tcp_server(recv, send, request, None).await {
         info!("tunnel ended: {e}");
     }
 }


### PR DESCRIPTION
## Summary

Two related commits on this branch:

1. **`066a9ee` — Add server admin API + `rusnel ctl` (read-only, v0.7.0).** Phase-1 of the long-tracked operability item: a read-only HTTP API on a unix socket (`~/.rusnel/admin.sock`, mode 0600) exposing live clients, tunnels, conns, per-tunnel byte counters, and a bounded disconnect-history ring buffer. New `rusnel ctl` subcommand wraps the API for the shell. Three-layer **client / tunnel / conn** data model in `ServerState` + DTOs.
2. **`6c80f95` — Replace per-stream `RemoteRequest` with session hello + `OpenConn` (v0.8.0).** Wire-protocol overhaul that follows chisel's session-config model. The 0.7 protocol re-sent a full `RemoteRequest` on every data-plane bi-stream and used an `announce_only` band-aid for forward-tunnel admin visibility; both are gone. Clients now declare every tunnel up front in `SessionHello`, server validates the batch and assigns `tunnel_id`s, every subsequent bi-stream opens with a tiny `OpenConn { tunnel_id, dynamic }` frame. SOCKS5 dynamic targets ride along as `OpenConn::dynamic` under the parent SOCKS tunnel, removing the `from_socks` flag.

### Breaking

- 0.8 wire format is **not backward compatible** with 0.7.x — upgrade both ends together.
- `RemoteRequest::announce_only` / `from_socks` and `dynamic_tcp` / `dynamic_udp` constructors removed.
- `ServerConfig` gains an `admin_socket: Option<PathBuf>` field (0.7).
- Tunnel handler signatures take a new `tunnel_id: u64` argument (0.8) and a `Counters` argument (0.7).
- Forward SOCKS5 with `--allow-socks=false` now fails the entire session at hello time instead of binding a local listener and rejecting per-CONNECT.

### Highlights

- New `/api/v1/{server,clients,clients/:id,clients/:id/{tunnels,conns},tunnels,tunnels/:id,tunnels/:id/conns,conns,conns/:id,history}` endpoints.
- `rusnel ctl {server,clients,client,client-conns,tunnels,tunnel,tunnel-conns,conns,history}` with table or `--json` output.
- `--no-admin-socket` flag to opt out; `--admin-socket <path>` to override.
- Single declaration path replaces three different ones (forward per-conn, reverse control, 0.7 announce).
- `find_or_create_tunnel` + `tunnel_index` dedup hack collapsed into a simple bulk `register_tunnels` — the protocol no longer needs runtime dedup.

## Test plan

- [x] `cargo build --release`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test --all` — full suite passes (admin, auth, combinations, concurrent, disconnect_cleanup, edge_cases, ipv6, large_transfer, proxy, reconnect, tunnels)
- [ ] Manual smoke: `rusnel server --admin-socket /tmp/r.sock` + `rusnel client --remote 1080:google.com:80` + `rusnel ctl --socket /tmp/r.sock tunnels` shows the tunnel before and after pushing traffic

Made with [Cursor](https://cursor.com)