### PR TITLE
Propagate TCP tunnel hard errors instead of waiting on QUIC idle timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-05-05
+
+Bug fix and integration-test expansion. The TCP tunnel now propagates
+hard errors (peer RST, abortive close mid-stream) across the QUIC
+connection in bounded time, instead of leaving the surviving direction
+blocked until the ~30 s idle timeout.
+
+### Fixed
+
+- **`tunnel_tcp_stream` no longer hangs the surviving direction on a
+  hard error.** The previous code used `tokio::join!` (intentional, to
+  preserve buffered bytes during graceful close) but had no error-path
+  bridge between the two copy futures: when one direction errored, the
+  other kept blocking on a QUIC read that would never produce data,
+  and the local `tcp_send` half wasn't dropped until QUIC's idle
+  timeout fired (~30 s). On hard errors the failing direction now
+  resets its `SendStream` (so the peer's `RecvStream` errors
+  immediately) and signals the local companion direction via a shared
+  `Notify` to abort its blocking copy and FIN the local TCP socket.
+  The graceful-close path (EOF → `shutdown().await`) is unchanged, so
+  no buffered bytes are lost on clean teardown.
+
+### Tests
+
+- Five new integration test files covering proxy semantics that were
+  previously uncovered: half-close in all four
+  forward/reverse × app→target/target→app variants plus SOCKS5
+  (`tests/half_close.rs`), abortive RST close in three variants and
+  reverse dead-target handling (`tests/abrupt_close.rs`), reverse-UDP
+  and reverse-SOCKS server-side listener cleanup on client disconnect
+  (extension to `tests/disconnect_cleanup.rs`), per-connection failure
+  isolation under multiplexing (extension to `tests/concurrent.rs`),
+  multi-client session isolation (`tests/multi_client.rs`), and UDP
+  per-sender response routing / oversized-datagram framing /
+  silent-target liveness (`tests/udp_semantics.rs`). Total suite is
+  now 124 tests, up from 109.
+
 ## [0.8.0] - 2026-05-03
 
 Wire-protocol overhaul. The per-stream `RemoteRequest` handshake — and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "rusnel"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusnel"
 description = "Rusnel is a fast TCP/UDP tunnel, transported over and encrypted using QUIC protocol. Single executable including both client and server"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/guyte149/Rusnel"

--- a/src/common/tcp.rs
+++ b/src/common/tcp.rs
@@ -2,10 +2,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use anyhow::Result;
-use quinn::{Connection, RecvStream, SendStream};
+use quinn::{Connection, RecvStream, SendStream, VarInt};
 use tokio::{
     io::{AsyncRead, AsyncWriteExt, BufReader},
     net::{TcpListener, TcpStream},
+    sync::Notify,
 };
 use tracing::{debug, debug_span, info, Instrument};
 
@@ -101,21 +102,100 @@ pub async fn tunnel_tcp_stream(
     let mut tcp_recv = BufReader::with_capacity(TUNNEL_COPY_BUF, tcp_recv);
     let mut quic_recv = BufReader::with_capacity(TUNNEL_COPY_BUF, quic_recv);
 
-    let client_to_server = async {
-        tokio::io::copy_buf(&mut tcp_recv, &mut send_channel).await?;
-        send_channel.shutdown().await?;
-        Ok::<(), anyhow::Error>(())
+    // Shared "abort" signal that one direction can fire to wake the other
+    // out of its blocking copy (see big comment on the join! call below).
+    // `Arc<Notify>` rather than a oneshot because both directions need to
+    // observe the same edge.
+    let abort: Arc<Notify> = Arc::new(Notify::new());
+    // RESET_STREAM error code we use when tearing a stream down on a hard
+    // error. Application-defined; nothing on the wire interprets it.
+    const ABORT_CODE: u32 = 0;
+
+    let client_to_server = {
+        let abort = abort.clone();
+        async move {
+            // `notified()` registers as a waiter the first time it's
+            // polled, which is what `select!` does on entry. With `biased`
+            // ordering we register before polling the copy, so a
+            // notify_waiters() racing the copy's first poll still wakes us.
+            let outcome = tokio::select! {
+                biased;
+                _ = abort.notified() => CopyOutcome::Aborted,
+                r = tokio::io::copy_buf(&mut tcp_recv, &mut send_channel) => match r {
+                    Ok(_) => CopyOutcome::Eof,
+                    Err(e) => CopyOutcome::Errored(e),
+                },
+            };
+            match outcome {
+                CopyOutcome::Eof => {
+                    // Graceful EOF: forward as FIN over QUIC. The peer's
+                    // server_to_client copy will see this as a clean
+                    // end-of-stream and drain any buffered bytes still
+                    // flowing in the other direction.
+                    let _ = send_channel.shutdown().await;
+                    Ok(())
+                }
+                CopyOutcome::Errored(e) | CopyOutcome::AbortedWith(e) => {
+                    let _ = send_channel.reset(VarInt::from_u32(ABORT_CODE));
+                    abort.notify_waiters();
+                    Err(anyhow::Error::from(e))
+                }
+                CopyOutcome::Aborted => {
+                    // The other direction errored and signalled us; tear
+                    // our send side down too so the peer's matching recv
+                    // unblocks instead of waiting for QUIC idle timeout.
+                    let _ = send_channel.reset(VarInt::from_u32(ABORT_CODE));
+                    Ok(())
+                }
+            }
+        }
     };
 
-    let server_to_client = async {
-        tokio::io::copy_buf(&mut quic_recv, &mut tcp_send).await?;
-        tcp_send.shutdown().await?;
-        Ok::<(), anyhow::Error>(())
+    let server_to_client = {
+        let abort = abort.clone();
+        async move {
+            let outcome = tokio::select! {
+                biased;
+                _ = abort.notified() => CopyOutcome::Aborted,
+                r = tokio::io::copy_buf(&mut quic_recv, &mut tcp_send) => match r {
+                    Ok(_) => CopyOutcome::Eof,
+                    Err(e) => CopyOutcome::Errored(e),
+                },
+            };
+            match outcome {
+                CopyOutcome::Eof => {
+                    let _ = tcp_send.shutdown().await;
+                    Ok(())
+                }
+                CopyOutcome::Errored(e) | CopyOutcome::AbortedWith(e) => {
+                    // FIN to the local TCP peer (best-effort — if the
+                    // socket is already RST'd, shutdown will fail and
+                    // there's nothing else to do).
+                    let _ = tcp_send.shutdown().await;
+                    abort.notify_waiters();
+                    Err(anyhow::Error::from(e))
+                }
+                CopyOutcome::Aborted => {
+                    let _ = tcp_send.shutdown().await;
+                    Ok(())
+                }
+            }
+        }
     };
 
-    // tokio::join! (not try_join!) so that an error in one direction doesn't
-    // cancel an in-flight copy in the other and silently lose buffered bytes
-    // (#20 §3). The application has already half-closed appropriately.
+    // tokio::join! (not try_join!) so that a graceful close in one
+    // direction (which surfaces as `Ok` from copy_buf and triggers a
+    // FIN/finish via `shutdown()`) doesn't cancel buffered bytes still
+    // draining in the other direction (#20 §3).
+    //
+    // For the *error* path we explicitly bridge the two halves with the
+    // `abort` Notify above: when one direction errors, it resets its
+    // QUIC send half (so the peer's recv errors immediately) and signals
+    // the other local future to stop blocking on its read. Without this,
+    // a hard error (peer RST, kernel-level disconnect) would hang the
+    // surviving half until QUIC's idle timeout (~30 s) tore the
+    // connection down — long enough that callers reasonably interpret
+    // it as a leak.
     let (c2s, s2c) = tokio::join!(client_to_server, server_to_client);
     match (&c2s, &s2c) {
         (Ok(_), Ok(_)) => debug!("closed"),
@@ -123,6 +203,17 @@ pub async fn tunnel_tcp_stream(
         (_, Err(e)) => debug!("server→client error: {}", e),
     }
     Ok(())
+}
+
+/// Outcome of a single-direction copy after the abort-aware select.
+/// `AbortedWith` is unused today but kept so the match arms stay
+/// exhaustive if a future variant carries a side-channel error.
+enum CopyOutcome {
+    Eof,
+    Errored(std::io::Error),
+    Aborted,
+    #[allow(dead_code)]
+    AbortedWith(std::io::Error),
 }
 
 pub async fn tunnel_tcp_client(

--- a/tests/abrupt_close.rs
+++ b/tests/abrupt_close.rs
@@ -1,0 +1,243 @@
+//! Abortive (RST) close and originator-side aborts.
+//!
+//! The half-close tests cover the *graceful* `shutdown(WRITE)` →
+//! FIN-propagation path. Real-world apps frequently abort connections —
+//! TCP RST from a crashed peer, an originator dropping its socket
+//! mid-transfer, etc. The tunnel must surface these as a bounded-time
+//! close on the other side, not hang for the QUIC idle timeout.
+//!
+//! Two paths (forward / reverse) and two RST-source sides (target /
+//! originator) are covered, since the copy loops in `tcp.rs` are
+//! symmetric-but-distinct call sites and a fix in one direction
+//! wouldn't necessarily land in the other. The reverse / dead-target
+//! case is the missing companion to
+//! `edge_cases.rs::test_tcp_forward_dead_target_closes_connection`.
+
+mod common;
+
+use std::io::ErrorKind;
+use std::str::FromStr;
+use std::time::Duration;
+
+use common::{get_available_port, start_tunnel, TEST_TIMEOUT};
+use rusnel::common::remote::RemoteRequest;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::timeout;
+
+/// Drop a TCP stream with a zero linger so the kernel sends RST instead
+/// of FIN. The `set_linger` accessor on `tokio::net::TcpStream` is marked
+/// deprecated (it blocks the thread on drop); blocking-on-drop is
+/// exactly what we want here — it forces the abortive close synchronously
+/// before the test moves on. The actual blocking is bounded by the
+/// zero-linger value, so this completes immediately.
+#[allow(deprecated)]
+fn rst_close(stream: TcpStream) {
+    let _ = stream.set_linger(Some(Duration::ZERO));
+    drop(stream);
+}
+
+/// Forward TCP: target sends RST mid-stream. The originating app must
+/// observe the connection ending in bounded time (read returns EOF or an
+/// error) — *not* hang on the read.
+#[tokio::test]
+async fn test_tcp_forward_target_rst_mid_stream() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let local_port = get_available_port();
+        let remote_port = get_available_port();
+
+        let target_listener = TcpListener::bind(format!("127.0.0.1:{remote_port}"))
+            .await
+            .unwrap();
+
+        let remote =
+            RemoteRequest::from_str(&format!("127.0.0.1:{local_port}:127.0.0.1:{remote_port}"))
+                .unwrap();
+        let _env = start_tunnel(server_port, false, vec![remote]).await;
+
+        let mut app = TcpStream::connect(format!("127.0.0.1:{local_port}"))
+            .await
+            .unwrap();
+        let (mut target, _) = target_listener.accept().await.unwrap();
+
+        app.write_all(b"hello").await.unwrap();
+        let mut buf = [0u8; 5];
+        target.read_exact(&mut buf).await.unwrap();
+
+        rst_close(target);
+
+        // App side must wake up with read returning 0 / error within a
+        // few seconds — not block forever waiting for a FIN that never
+        // comes.
+        let mut buf = [0u8; 16];
+        let result = timeout(Duration::from_secs(5), app.read(&mut buf))
+            .await
+            .expect("app never observed target RST as connection end");
+        match result {
+            Ok(0) => {} // EOF — acceptable
+            Ok(n) => panic!("unexpected {n} trailing bytes after target RST"),
+            Err(e) => assert!(
+                matches!(
+                    e.kind(),
+                    ErrorKind::ConnectionReset
+                        | ErrorKind::BrokenPipe
+                        | ErrorKind::UnexpectedEof
+                        | ErrorKind::ConnectionAborted
+                ),
+                "unexpected error kind {:?}",
+                e.kind()
+            ),
+        }
+    })
+    .await
+    .expect("test_tcp_forward_target_rst_mid_stream timed out");
+}
+
+/// Forward TCP: the originating app aborts (RST) mid-transfer. The target
+/// must see its end of the tunnel close in bounded time so it can release
+/// resources — without this, a misbehaving local app could pin upstream
+/// connections indefinitely.
+#[tokio::test]
+async fn test_tcp_forward_app_rst_mid_stream() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let local_port = get_available_port();
+        let remote_port = get_available_port();
+
+        let target_listener = TcpListener::bind(format!("127.0.0.1:{remote_port}"))
+            .await
+            .unwrap();
+
+        let remote =
+            RemoteRequest::from_str(&format!("127.0.0.1:{local_port}:127.0.0.1:{remote_port}"))
+                .unwrap();
+        let _env = start_tunnel(server_port, false, vec![remote]).await;
+
+        let mut app = TcpStream::connect(format!("127.0.0.1:{local_port}"))
+            .await
+            .unwrap();
+        let (mut target, _) = target_listener.accept().await.unwrap();
+
+        app.write_all(b"abc").await.unwrap();
+        let mut buf = [0u8; 3];
+        target.read_exact(&mut buf).await.unwrap();
+
+        rst_close(app);
+
+        let mut buf = [0u8; 16];
+        let result = timeout(Duration::from_secs(5), target.read(&mut buf))
+            .await
+            .expect("target never observed app RST");
+        match result {
+            Ok(0) => {}
+            Ok(n) => panic!("unexpected {n} trailing bytes after app RST"),
+            Err(e) => assert!(
+                matches!(
+                    e.kind(),
+                    ErrorKind::ConnectionReset
+                        | ErrorKind::BrokenPipe
+                        | ErrorKind::UnexpectedEof
+                        | ErrorKind::ConnectionAborted
+                ),
+                "unexpected error kind {:?}",
+                e.kind()
+            ),
+        }
+    })
+    .await
+    .expect("test_tcp_forward_app_rst_mid_stream timed out");
+}
+
+/// Reverse TCP: originating app aborts (RST). Mirror of the forward case
+/// but on the reverse path — the bytes flow in the opposite direction
+/// and the copy loops live in different functions.
+#[tokio::test]
+async fn test_tcp_reverse_app_rst_mid_stream() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let listen_port = get_available_port();
+        let target_port = get_available_port();
+
+        let target_listener = TcpListener::bind(format!("127.0.0.1:{target_port}"))
+            .await
+            .unwrap();
+
+        let remote = RemoteRequest::from_str(&format!(
+            "R:127.0.0.1:{listen_port}:127.0.0.1:{target_port}"
+        ))
+        .unwrap();
+        let _env = start_tunnel(server_port, true, vec![remote]).await;
+
+        let mut app = TcpStream::connect(format!("127.0.0.1:{listen_port}"))
+            .await
+            .unwrap();
+        let (mut target, _) = target_listener.accept().await.unwrap();
+
+        app.write_all(b"abc").await.unwrap();
+        let mut buf = [0u8; 3];
+        target.read_exact(&mut buf).await.unwrap();
+
+        rst_close(app);
+
+        let mut buf = [0u8; 16];
+        let result = timeout(Duration::from_secs(5), target.read(&mut buf))
+            .await
+            .expect("target never observed app RST on reverse path");
+        match result {
+            Ok(0) => {}
+            Ok(n) => panic!("unexpected {n} trailing bytes after app RST (reverse)"),
+            Err(e) => assert!(
+                matches!(
+                    e.kind(),
+                    ErrorKind::ConnectionReset
+                        | ErrorKind::BrokenPipe
+                        | ErrorKind::UnexpectedEof
+                        | ErrorKind::ConnectionAborted
+                ),
+                "unexpected error kind {:?}",
+                e.kind()
+            ),
+        }
+    })
+    .await
+    .expect("test_tcp_reverse_app_rst_mid_stream timed out");
+}
+
+/// Reverse TCP target is dead (port unbound). Counterpart to
+/// `test_tcp_forward_dead_target_closes_connection` in `edge_cases.rs`,
+/// but on the reverse path. The server-side accepted socket must close
+/// promptly when the client side fails to dial the target — not hang
+/// holding the kernel-side TCP state.
+#[tokio::test]
+async fn test_tcp_reverse_dead_target_closes_connection() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let listen_port = get_available_port();
+        // Reserved-then-dropped — small race on loopback, fine in CI.
+        let dead_target_port = get_available_port();
+
+        let remote = RemoteRequest::from_str(&format!(
+            "R:127.0.0.1:{listen_port}:127.0.0.1:{dead_target_port}"
+        ))
+        .unwrap();
+        let _env = start_tunnel(server_port, true, vec![remote]).await;
+
+        let mut app = TcpStream::connect(format!("127.0.0.1:{listen_port}"))
+            .await
+            .unwrap();
+        let _ = app.write_all(b"x").await;
+
+        let mut buf = [0u8; 16];
+        let n = timeout(Duration::from_secs(5), app.read(&mut buf))
+            .await
+            .expect("client never observed reverse-tunnel teardown for dead target")
+            .unwrap_or(0);
+        assert_eq!(
+            n, 0,
+            "expected EOF from reverse tunnel pointing at dead target"
+        );
+    })
+    .await
+    .expect("test_tcp_reverse_dead_target_closes_connection timed out");
+}

--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -383,3 +383,99 @@ async fn test_udp_forward_multiple_senders() {
     .await
     .expect("test_udp_forward_multiple_senders timed out");
 }
+
+/// Open several concurrent TCP forward connections through one tunnel,
+/// abort *one* of them mid-stream (RST), and verify every other
+/// connection completes its round-trip cleanly. Catches regressions
+/// where a single failing per-connection task tears down its siblings
+/// (shared `?` propagation, joined `try_join!` instead of `join!`,
+/// shared QUIC stream state, etc.).
+#[tokio::test]
+async fn test_tcp_forward_per_connection_failure_isolation() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let local_port = get_available_port();
+        let target_port = get_available_port();
+
+        let target_listener = TcpListener::bind(format!("127.0.0.1:{target_port}"))
+            .await
+            .unwrap();
+
+        // Server-side accept loop: read a length byte, echo back N bytes
+        // of the payload. The "bad" connection is identified by being
+        // RST'd by the client side mid-read; the others must still get
+        // their full echo.
+        let acceptor = tokio::spawn(async move {
+            for _ in 0..5 {
+                let (mut s, _) = target_listener.accept().await.unwrap();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 16];
+                    loop {
+                        match s.read(&mut buf).await {
+                            Ok(0) => return,
+                            Ok(n) => {
+                                if s.write_all(&buf[..n]).await.is_err() {
+                                    return;
+                                }
+                            }
+                            Err(_) => return,
+                        }
+                    }
+                });
+            }
+        });
+
+        let remote =
+            RemoteRequest::from_str(&format!("127.0.0.1:{local_port}:127.0.0.1:{target_port}"))
+                .unwrap();
+        let _env = start_tunnel(server_port, false, vec![remote]).await;
+
+        // Open 5 conns. Conn 0 will be RST. Conns 1..5 must echo OK.
+        let mut conns = Vec::new();
+        for i in 0..5u8 {
+            let c = TcpStream::connect(format!("127.0.0.1:{local_port}"))
+                .await
+                .unwrap();
+            // Write a marker so the server-side accept actually pairs
+            // up before we abort conn 0.
+            let mut c = c;
+            c.write_all(&[i, b'!']).await.unwrap();
+            conns.push(c);
+        }
+
+        // Drain the round-trip for the marker on each conn.
+        for (i, c) in conns.iter_mut().enumerate() {
+            let mut buf = [0u8; 2];
+            c.read_exact(&mut buf).await.unwrap();
+            assert_eq!(buf[0], i as u8);
+        }
+
+        // Abortive close on conn 0. `set_linger` is deprecated on
+        // tokio's TcpStream because it blocks-on-drop, which is exactly
+        // what we want here to force the RST out synchronously.
+        let bad = conns.remove(0);
+        #[allow(deprecated)]
+        {
+            let _ = bad.set_linger(Some(Duration::ZERO));
+        }
+        drop(bad);
+
+        // The remaining four connections must still echo a fresh
+        // payload and close cleanly.
+        for (i, mut c) in conns.into_iter().enumerate() {
+            let payload = format!("ok-{i}");
+            c.write_all(payload.as_bytes()).await.unwrap();
+            let mut buf = vec![0u8; payload.len()];
+            timeout(Duration::from_secs(5), c.read_exact(&mut buf))
+                .await
+                .unwrap_or_else(|_| panic!("conn {i} stalled after sibling RST"))
+                .unwrap_or_else(|e| panic!("conn {i} failed after sibling RST: {e}"));
+            assert_eq!(buf, payload.as_bytes());
+            c.shutdown().await.ok();
+        }
+
+        acceptor.abort();
+    })
+    .await
+    .expect("test_tcp_forward_per_connection_failure_isolation timed out");
+}

--- a/tests/disconnect_cleanup.rs
+++ b/tests/disconnect_cleanup.rs
@@ -240,10 +240,8 @@ async fn test_server_releases_reverse_socks_listener_on_client_disconnect() {
             .await
             .unwrap();
 
-        let remote = RemoteRequest::from_str(&format!(
-            "R:127.0.0.1:{reverse_listen_port}:socks"
-        ))
-        .unwrap();
+        let remote =
+            RemoteRequest::from_str(&format!("R:127.0.0.1:{reverse_listen_port}:socks")).unwrap();
         let (mut send, mut recv) = connection.open_bi().await.unwrap();
         let hello = SessionHello {
             remotes: vec![remote],

--- a/tests/disconnect_cleanup.rs
+++ b/tests/disconnect_cleanup.rs
@@ -19,13 +19,17 @@ use rusnel::common::quic::{create_client_endpoint, Congestion};
 use rusnel::common::remote::{RemoteRequest, SessionHello};
 use rusnel::common::tls::ClientTlsConfig;
 use rusnel::common::tunnel::client_send_session_hello;
-use tokio::net::TcpListener;
+use tokio::net::{TcpListener, UdpSocket};
 use tokio::time::timeout;
 
 /// Try to bind `127.0.0.1:port`. Returns `true` if the port is currently
 /// free (rebindable) and `false` if something else still holds it.
 async fn port_is_free(port: u16) -> bool {
     TcpListener::bind(format!("127.0.0.1:{port}")).await.is_ok()
+}
+
+async fn udp_port_is_free(port: u16) -> bool {
+    UdpSocket::bind(format!("127.0.0.1:{port}")).await.is_ok()
 }
 
 /// Poll until the predicate is satisfied or the deadline expires.
@@ -137,4 +141,141 @@ async fn test_server_releases_reverse_listener_on_client_disconnect() {
     })
     .await
     .expect("test_server_releases_reverse_listener_on_client_disconnect timed out");
+}
+
+/// Same shape as the reverse-TCP cleanup test, but for **reverse UDP**.
+/// The server binds a `UdpSocket` on the reverse-listen port and pumps
+/// datagrams back to the client over a per-source QUIC stream. The
+/// JoinSet that owns this UDP pump must be aborted on client
+/// disconnect so the UDP port is released.
+#[tokio::test]
+async fn test_server_releases_reverse_udp_socket_on_client_disconnect() {
+    timeout(Duration::from_secs(30), async {
+        init_crypto();
+        let server_port = get_available_port();
+        let reverse_listen_port = get_available_port();
+        let reverse_target_port = get_available_port();
+
+        let sc = server_config(server_port, true);
+        let server_handle = tokio::spawn(async move {
+            let _ = rusnel::server::run_async(sc).await;
+        });
+        tokio::time::sleep(STARTUP_DELAY).await;
+
+        let server_addr: SocketAddr = (IpAddr::V4(Ipv4Addr::LOCALHOST), server_port).into();
+        let endpoint =
+            create_client_endpoint(&ClientTlsConfig::Insecure, Congestion::Cubic, server_addr)
+                .unwrap();
+        let connection = endpoint
+            .connect(server_addr, "127.0.0.1")
+            .unwrap()
+            .await
+            .unwrap();
+
+        let remote = RemoteRequest::from_str(&format!(
+            "R:127.0.0.1:{reverse_listen_port}:127.0.0.1:{reverse_target_port}/udp"
+        ))
+        .unwrap();
+        let (mut send, mut recv) = connection.open_bi().await.unwrap();
+        let hello = SessionHello {
+            remotes: vec![remote],
+        };
+        let _ = client_send_session_hello(&hello, &mut send, &mut recv)
+            .await
+            .unwrap();
+
+        let bound = wait_until(Duration::from_secs(10), || async {
+            !udp_port_is_free(reverse_listen_port).await
+        })
+        .await;
+        assert!(
+            bound,
+            "server never bound the reverse UDP socket on port {reverse_listen_port}"
+        );
+
+        connection.close(VarInt::from_u32(0), b"test done");
+        endpoint.wait_idle().await;
+
+        let freed = wait_until(Duration::from_secs(5), || async {
+            udp_port_is_free(reverse_listen_port).await
+        })
+        .await;
+        assert!(
+            freed,
+            "server never released reverse UDP socket on port {reverse_listen_port} \
+             after client disconnect"
+        );
+
+        server_handle.abort();
+    })
+    .await
+    .expect("test_server_releases_reverse_udp_socket_on_client_disconnect timed out");
+}
+
+/// Reverse SOCKS cleanup: server binds a `TcpListener` on the
+/// reverse-listen port and runs the SOCKS5 negotiation loop. Same
+/// JoinSet-lifecycle invariant as the plain reverse-TCP test, but the
+/// listener task lives in a different module (`socks.rs`) and could
+/// reasonably regress independently.
+#[tokio::test]
+async fn test_server_releases_reverse_socks_listener_on_client_disconnect() {
+    timeout(Duration::from_secs(30), async {
+        init_crypto();
+        let server_port = get_available_port();
+        let reverse_listen_port = get_available_port();
+
+        let sc = server_config(server_port, true);
+        let server_handle = tokio::spawn(async move {
+            let _ = rusnel::server::run_async(sc).await;
+        });
+        tokio::time::sleep(STARTUP_DELAY).await;
+
+        let server_addr: SocketAddr = (IpAddr::V4(Ipv4Addr::LOCALHOST), server_port).into();
+        let endpoint =
+            create_client_endpoint(&ClientTlsConfig::Insecure, Congestion::Cubic, server_addr)
+                .unwrap();
+        let connection = endpoint
+            .connect(server_addr, "127.0.0.1")
+            .unwrap()
+            .await
+            .unwrap();
+
+        let remote = RemoteRequest::from_str(&format!(
+            "R:127.0.0.1:{reverse_listen_port}:socks"
+        ))
+        .unwrap();
+        let (mut send, mut recv) = connection.open_bi().await.unwrap();
+        let hello = SessionHello {
+            remotes: vec![remote],
+        };
+        let _ = client_send_session_hello(&hello, &mut send, &mut recv)
+            .await
+            .unwrap();
+
+        let bound = wait_until(Duration::from_secs(10), || async {
+            !port_is_free(reverse_listen_port).await
+        })
+        .await;
+        assert!(
+            bound,
+            "server never bound the reverse SOCKS listener on port {reverse_listen_port}"
+        );
+
+        connection.close(VarInt::from_u32(0), b"test done");
+        endpoint.wait_idle().await;
+
+        let freed = wait_until(Duration::from_secs(5), || async {
+            port_is_free(reverse_listen_port).await
+        })
+        .await;
+        assert!(
+            freed,
+            "server never released reverse SOCKS listener on port {reverse_listen_port} \
+             after client disconnect"
+        );
+
+        server_handle.abort();
+    })
+    .await
+    .expect("test_server_releases_reverse_socks_listener_on_client_disconnect timed out");
 }

--- a/tests/half_close.rs
+++ b/tests/half_close.rs
@@ -1,0 +1,204 @@
+//! Half-close (TCP `shutdown(WRITE)`) propagation across the tunnel.
+//!
+//! `edge_cases.rs::test_tcp_forward_half_close` covers exactly one direction
+//! of one tunnel mode. The proxy code path that copies bytes between the
+//! TCP socket and the QUIC stream is symmetric on paper but the four
+//! variants (forward/reverse × app→target / target→app) live in separate
+//! `tokio::join!` arms with their own `shutdown()` / `finish()` plumbing,
+//! and a half-close bug in only one direction is the most common shape of
+//! a TCP-proxy regression. Each variant gets its own test.
+
+mod common;
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use common::{
+    get_available_port, socks5_connect_ipv4, start_tunnel, start_tunnel_with_flags, TEST_TIMEOUT,
+};
+use rusnel::common::remote::RemoteRequest;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::timeout;
+
+/// Forward TCP, **target**-initiated half-close. The target writes a
+/// response, shuts its write half, then reads. The originating app must
+/// see the bytes + EOF, then be able to push trailing bytes (think
+/// HTTP/1.0 reply where the server closes WR but still wants to drain
+/// the request body).
+#[tokio::test]
+async fn test_tcp_forward_target_initiated_half_close() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let local_port = get_available_port();
+        let remote_port = get_available_port();
+
+        let target_listener = TcpListener::bind(format!("127.0.0.1:{remote_port}"))
+            .await
+            .unwrap();
+
+        let remote =
+            RemoteRequest::from_str(&format!("127.0.0.1:{local_port}:127.0.0.1:{remote_port}"))
+                .unwrap();
+        let _env = start_tunnel(server_port, false, vec![remote]).await;
+
+        let mut app = TcpStream::connect(format!("127.0.0.1:{local_port}"))
+            .await
+            .unwrap();
+        let (mut target, _) = target_listener.accept().await.unwrap();
+
+        // Target speaks first and half-closes its write half.
+        target.write_all(b"server-hello").await.unwrap();
+        target.shutdown().await.unwrap();
+
+        let mut got = Vec::new();
+        app.read_to_end(&mut got).await.unwrap();
+        assert_eq!(got, b"server-hello", "app must see target payload + EOF");
+
+        // App writes its trailing payload, then closes — target must drain it.
+        app.write_all(b"client-trailer").await.unwrap();
+        app.shutdown().await.unwrap();
+        let mut buf = Vec::new();
+        target.read_to_end(&mut buf).await.unwrap();
+        assert_eq!(buf, b"client-trailer", "target must drain app's trailer");
+    })
+    .await
+    .expect("test_tcp_forward_target_initiated_half_close timed out");
+}
+
+/// Reverse TCP, originator (app) → target half-close. The reverse path
+/// runs the listener on the *server* side and forwards accepted sockets
+/// over QUIC to the *client* side, where they're dialed to the configured
+/// target. App writes + half-closes; target sees EOF; target replies and
+/// closes; app reads the reply.
+#[tokio::test]
+async fn test_tcp_reverse_app_to_target_half_close() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let listen_port = get_available_port();
+        let target_port = get_available_port();
+
+        let target_listener = TcpListener::bind(format!("127.0.0.1:{target_port}"))
+            .await
+            .unwrap();
+
+        let remote = RemoteRequest::from_str(&format!(
+            "R:127.0.0.1:{listen_port}:127.0.0.1:{target_port}"
+        ))
+        .unwrap();
+        let _env = start_tunnel(server_port, true, vec![remote]).await;
+
+        let mut app = TcpStream::connect(format!("127.0.0.1:{listen_port}"))
+            .await
+            .unwrap();
+        let (mut target, _) = target_listener.accept().await.unwrap();
+
+        app.write_all(b"req").await.unwrap();
+        app.shutdown().await.unwrap();
+
+        let mut buf = vec![0u8; 64];
+        let n = target.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"req");
+        let n = target.read(&mut buf).await.unwrap();
+        assert_eq!(n, 0, "target must observe EOF after app shutdown");
+
+        target.write_all(b"resp").await.unwrap();
+        target.shutdown().await.unwrap();
+        let mut got = Vec::new();
+        app.read_to_end(&mut got).await.unwrap();
+        assert_eq!(got, b"resp");
+    })
+    .await
+    .expect("test_tcp_reverse_app_to_target_half_close timed out");
+}
+
+/// Reverse TCP, **target** → app half-close. Mirrors the forward-direction
+/// test_tcp_forward_target_initiated_half_close but on the reverse path.
+#[tokio::test]
+async fn test_tcp_reverse_target_initiated_half_close() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let listen_port = get_available_port();
+        let target_port = get_available_port();
+
+        let target_listener = TcpListener::bind(format!("127.0.0.1:{target_port}"))
+            .await
+            .unwrap();
+
+        let remote = RemoteRequest::from_str(&format!(
+            "R:127.0.0.1:{listen_port}:127.0.0.1:{target_port}"
+        ))
+        .unwrap();
+        let _env = start_tunnel(server_port, true, vec![remote]).await;
+
+        let mut app = TcpStream::connect(format!("127.0.0.1:{listen_port}"))
+            .await
+            .unwrap();
+        let (mut target, _) = target_listener.accept().await.unwrap();
+
+        target.write_all(b"server-hello").await.unwrap();
+        target.shutdown().await.unwrap();
+
+        let mut got = Vec::new();
+        app.read_to_end(&mut got).await.unwrap();
+        assert_eq!(got, b"server-hello");
+
+        app.write_all(b"client-trailer").await.unwrap();
+        app.shutdown().await.unwrap();
+        let mut buf = Vec::new();
+        target.read_to_end(&mut buf).await.unwrap();
+        assert_eq!(buf, b"client-trailer");
+    })
+    .await
+    .expect("test_tcp_reverse_target_initiated_half_close timed out");
+}
+
+/// SOCKS5 forward, app → target half-close. The SOCKS5 CONNECT proxy code
+/// path lives in `src/common/socks.rs` and wires up its own copy loops —
+/// distinct from the plain TCP forward path in `tcp.rs`. Test it
+/// separately so a half-close regression in the SOCKS code can't hide
+/// behind a passing TCP test.
+#[tokio::test]
+async fn test_socks5_forward_half_close() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let socks_port = get_available_port();
+        let target_port = get_available_port();
+
+        let target_listener = TcpListener::bind(format!("127.0.0.1:{target_port}"))
+            .await
+            .unwrap();
+
+        let remote = RemoteRequest::from_str(&format!("127.0.0.1:{socks_port}:socks")).unwrap();
+        let _env = start_tunnel_with_flags(server_port, false, true, vec![remote]).await;
+
+        let mut app = socks5_connect_ipv4(
+            &format!("127.0.0.1:{socks_port}"),
+            [127, 0, 0, 1],
+            target_port,
+        )
+        .await;
+        let (mut target, _) = target_listener.accept().await.unwrap();
+
+        app.write_all(b"req").await.unwrap();
+        app.shutdown().await.unwrap();
+
+        let mut buf = vec![0u8; 64];
+        let n = target.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"req");
+        let n = timeout(Duration::from_secs(3), target.read(&mut buf))
+            .await
+            .expect("SOCKS path never propagated app's half-close as EOF")
+            .unwrap();
+        assert_eq!(n, 0, "expected EOF after app shutdown via SOCKS");
+
+        target.write_all(b"resp").await.unwrap();
+        target.shutdown().await.unwrap();
+
+        let mut got = Vec::new();
+        app.read_to_end(&mut got).await.unwrap();
+        assert_eq!(got, b"resp");
+    })
+    .await
+    .expect("test_socks5_forward_half_close timed out");
+}

--- a/tests/multi_client.rs
+++ b/tests/multi_client.rs
@@ -1,0 +1,204 @@
+//! Multiple clients sharing a single server.
+//!
+//! All other tests spawn exactly one rusnel client, so the server's
+//! per-session handler is only ever exercised against a single live
+//! connection. This file pins down the multi-client invariants:
+//!
+//!   * Two clients with disjoint forward tunnels both work concurrently.
+//!   * One client disconnecting (graceful or abrupt) does not perturb
+//!     the other client's in-flight or future traffic.
+
+mod common;
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use common::{
+    client_config, get_available_port, init_crypto, server_config, STARTUP_DELAY, TEST_TIMEOUT,
+};
+use rusnel::common::remote::RemoteRequest;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::timeout;
+
+/// Spawn a server task and return a handle that aborts it on drop.
+struct ServerGuard(tokio::task::JoinHandle<()>);
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+struct ClientGuard(tokio::task::JoinHandle<()>);
+impl Drop for ClientGuard {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+async fn spawn_server(server_port: u16) -> ServerGuard {
+    init_crypto();
+    let sc = server_config(server_port, false);
+    let h = tokio::spawn(async move {
+        let _ = rusnel::server::run_async(sc).await;
+    });
+    tokio::time::sleep(STARTUP_DELAY).await;
+    ServerGuard(h)
+}
+
+async fn spawn_client(server_port: u16, remotes: Vec<RemoteRequest>) -> ClientGuard {
+    let cc = client_config(server_port, remotes);
+    let h = tokio::spawn(async move {
+        let _ = rusnel::client::run_async(cc).await;
+    });
+    tokio::time::sleep(STARTUP_DELAY).await;
+    ClientGuard(h)
+}
+
+/// Two clients, each owning its own forward TCP tunnel through the same
+/// server, both work in parallel — disjoint sessions, no port collisions,
+/// both round-trips succeed.
+#[tokio::test]
+async fn test_two_clients_concurrent_traffic() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let local_a = get_available_port();
+        let target_a = get_available_port();
+        let local_b = get_available_port();
+        let target_b = get_available_port();
+
+        let listener_a = TcpListener::bind(format!("127.0.0.1:{target_a}"))
+            .await
+            .unwrap();
+        let listener_b = TcpListener::bind(format!("127.0.0.1:{target_b}"))
+            .await
+            .unwrap();
+
+        let _server = spawn_server(server_port).await;
+        let _ca = spawn_client(
+            server_port,
+            vec![
+                RemoteRequest::from_str(&format!("127.0.0.1:{local_a}:127.0.0.1:{target_a}"))
+                    .unwrap(),
+            ],
+        )
+        .await;
+        let _cb = spawn_client(
+            server_port,
+            vec![
+                RemoteRequest::from_str(&format!("127.0.0.1:{local_b}:127.0.0.1:{target_b}"))
+                    .unwrap(),
+            ],
+        )
+        .await;
+
+        let (mut app_a, mut app_b) = tokio::join!(
+            async {
+                TcpStream::connect(format!("127.0.0.1:{local_a}"))
+                    .await
+                    .unwrap()
+            },
+            async {
+                TcpStream::connect(format!("127.0.0.1:{local_b}"))
+                    .await
+                    .unwrap()
+            },
+        );
+        app_a.write_all(b"AAA").await.unwrap();
+        app_b.write_all(b"BBB").await.unwrap();
+        app_a.shutdown().await.unwrap();
+        app_b.shutdown().await.unwrap();
+
+        let (mut srv_a, _) = listener_a.accept().await.unwrap();
+        let (mut srv_b, _) = listener_b.accept().await.unwrap();
+        let mut got_a = Vec::new();
+        let mut got_b = Vec::new();
+        srv_a.read_to_end(&mut got_a).await.unwrap();
+        srv_b.read_to_end(&mut got_b).await.unwrap();
+
+        assert_eq!(got_a, b"AAA");
+        assert_eq!(got_b, b"BBB");
+    })
+    .await
+    .expect("test_two_clients_concurrent_traffic timed out");
+}
+
+/// Aborting client A's task must not knock client B's tunnels offline.
+/// This is the regression test for any state shared across sessions on
+/// the server (a single accept loop bug, a global JoinSet, a port
+/// registry, etc.) that would tear down B when A's handler unwinds.
+#[tokio::test]
+async fn test_one_client_disconnect_doesnt_affect_other() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let local_a = get_available_port();
+        let target_a = get_available_port();
+        let local_b = get_available_port();
+        let target_b = get_available_port();
+
+        let _listener_a = TcpListener::bind(format!("127.0.0.1:{target_a}"))
+            .await
+            .unwrap();
+        let listener_b = TcpListener::bind(format!("127.0.0.1:{target_b}"))
+            .await
+            .unwrap();
+
+        let _server = spawn_server(server_port).await;
+        let client_a = spawn_client(
+            server_port,
+            vec![
+                RemoteRequest::from_str(&format!("127.0.0.1:{local_a}:127.0.0.1:{target_a}"))
+                    .unwrap(),
+            ],
+        )
+        .await;
+        let _client_b = spawn_client(
+            server_port,
+            vec![
+                RemoteRequest::from_str(&format!("127.0.0.1:{local_b}:127.0.0.1:{target_b}"))
+                    .unwrap(),
+            ],
+        )
+        .await;
+
+        // Verify B works before tearing down A.
+        {
+            let mut app = TcpStream::connect(format!("127.0.0.1:{local_b}"))
+                .await
+                .unwrap();
+            app.write_all(b"pre").await.unwrap();
+            app.shutdown().await.unwrap();
+            let (mut s, _) = listener_b.accept().await.unwrap();
+            let mut got = Vec::new();
+            s.read_to_end(&mut got).await.unwrap();
+            assert_eq!(got, b"pre");
+        }
+
+        // Abort client A. The server-side handler for A's session should
+        // unwind, tear down only A's tunnels, and leave B's session
+        // running.
+        client_a.0.abort();
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // B must still be live. Use a fresh connection through B's
+        // tunnel — if the server collapsed B's session, this connect
+        // will succeed locally (the client-side listener is still up)
+        // but no bytes will reach the target.
+        let mut app = TcpStream::connect(format!("127.0.0.1:{local_b}"))
+            .await
+            .unwrap();
+        app.write_all(b"post").await.unwrap();
+        app.shutdown().await.unwrap();
+        let (mut s, _) = timeout(Duration::from_secs(5), listener_b.accept())
+            .await
+            .expect("client B's tunnel went dark after client A disconnected")
+            .unwrap();
+        let mut got = Vec::new();
+        s.read_to_end(&mut got).await.unwrap();
+        assert_eq!(
+            got, b"post",
+            "client B traffic must survive client A disconnect"
+        );
+    })
+    .await
+    .expect("test_one_client_disconnect_doesnt_affect_other timed out");
+}

--- a/tests/udp_semantics.rs
+++ b/tests/udp_semantics.rs
@@ -1,0 +1,200 @@
+//! UDP-specific semantics that the basic `tunnels.rs::test_udp_forward`
+//! happy path doesn't exercise.
+//!
+//! Forward UDP multiplexes by source `SocketAddr` onto per-source QUIC
+//! bi-streams (see `src/common/udp.rs::tunnel_udp_client`). The
+//! interesting behaviours that need pinning down are:
+//!
+//!   * Replies from the target are routed back to the *correct* origin
+//!     sender, not broadcast or aliased.
+//!   * Large datagrams (close to the 65 535-byte u16 length-prefix limit)
+//!     traverse the length-framing intact.
+//!   * The per-source state machine survives a target that simply never
+//!     replies — an idle source must not poison the next datagram.
+
+mod common;
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use common::{get_available_port, get_available_udp_port, start_tunnel, TEST_TIMEOUT};
+use rusnel::common::remote::RemoteRequest;
+use tokio::net::UdpSocket;
+use tokio::time::timeout;
+
+/// Two distinct local senders share one forward-UDP tunnel. The target
+/// echoes back to the original peer; each sender must receive **only**
+/// its own echo — i.e. the per-source map routes replies correctly.
+#[tokio::test]
+async fn test_udp_forward_response_routed_per_sender() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let local_port = get_available_udp_port();
+        let remote_port = get_available_udp_port();
+
+        let target = UdpSocket::bind(format!("127.0.0.1:{remote_port}"))
+            .await
+            .unwrap();
+        // Echo until the test ends.
+        let target_handle = tokio::spawn(async move {
+            let mut buf = vec![0u8; 2048];
+            loop {
+                match target.recv_from(&mut buf).await {
+                    Ok((n, peer)) => {
+                        let _ = target.send_to(&buf[..n], peer).await;
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let remote = RemoteRequest::from_str(&format!(
+            "127.0.0.1:{local_port}:127.0.0.1:{remote_port}/udp"
+        ))
+        .unwrap();
+        let _env = start_tunnel(server_port, false, vec![remote]).await;
+
+        let sender_a = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let sender_b = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let tunnel = format!("127.0.0.1:{local_port}");
+
+        sender_a.send_to(b"AAA", &tunnel).await.unwrap();
+        sender_b.send_to(b"BBB", &tunnel).await.unwrap();
+
+        let mut buf = vec![0u8; 64];
+        let n_a = timeout(Duration::from_secs(5), sender_a.recv(&mut buf))
+            .await
+            .expect("sender A never received its echo")
+            .unwrap();
+        assert_eq!(&buf[..n_a], b"AAA", "sender A got someone else's reply");
+
+        let mut buf = vec![0u8; 64];
+        let n_b = timeout(Duration::from_secs(5), sender_b.recv(&mut buf))
+            .await
+            .expect("sender B never received its echo")
+            .unwrap();
+        assert_eq!(&buf[..n_b], b"BBB", "sender B got someone else's reply");
+
+        target_handle.abort();
+    })
+    .await
+    .expect("test_udp_forward_response_routed_per_sender timed out");
+}
+
+/// Datagram payload that crosses the QUIC datagram boundary inside
+/// the QUIC stream. Exercises the `write_datagram` / `read_datagram`
+/// length-prefix framing in `src/common/udp.rs` — without the prefix,
+/// reads on the far side could split or coalesce datagrams and the
+/// payload would arrive truncated or merged. Sized to stay below
+/// per-OS UDP send limits (macOS defaults to 9216).
+#[tokio::test]
+async fn test_udp_forward_oversized_datagram_round_trip() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let local_port = get_available_udp_port();
+        let remote_port = get_available_udp_port();
+
+        let target = UdpSocket::bind(format!("127.0.0.1:{remote_port}"))
+            .await
+            .unwrap();
+        // 8 KB is bigger than any normal path-MTU-bound payload and
+        // bigger than a single QUIC datagram, so it exercises the
+        // length-prefix framing in `write_datagram`/`read_datagram`.
+        // Stays comfortably below per-OS UDP send limits (macOS
+        // defaults `net.inet.udp.maxdgram` to 9216, Linux is much
+        // higher) so this is portable across CI hosts.
+        let payload: Vec<u8> = (0..8_192u32).map(|i| (i % 251) as u8).collect();
+        let payload_for_target = payload.clone();
+        let target_handle = tokio::spawn(async move {
+            let mut buf = vec![0u8; 16_384];
+            let (n, peer) = target.recv_from(&mut buf).await.unwrap();
+            assert_eq!(&buf[..n], payload_for_target.as_slice());
+            target.send_to(&buf[..n], peer).await.unwrap();
+        });
+
+        let remote = RemoteRequest::from_str(&format!(
+            "127.0.0.1:{local_port}:127.0.0.1:{remote_port}/udp"
+        ))
+        .unwrap();
+        let _env = start_tunnel(server_port, false, vec![remote]).await;
+
+        let sender = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        sender
+            .send_to(&payload, format!("127.0.0.1:{local_port}"))
+            .await
+            .unwrap();
+
+        let mut buf = vec![0u8; 16_384];
+        let n = timeout(Duration::from_secs(10), sender.recv(&mut buf))
+            .await
+            .expect("large UDP datagram never echoed back")
+            .unwrap();
+        assert_eq!(n, payload.len(), "echo length mismatch");
+        assert_eq!(&buf[..n], payload.as_slice(), "echo payload corrupted");
+
+        target_handle.await.unwrap();
+    })
+    .await
+    .expect("test_udp_forward_oversized_datagram_round_trip timed out");
+}
+
+/// A target that never replies must not wedge the tunnel. Send one
+/// "lost" datagram from sender A (target ignores it), then verify a
+/// fresh datagram from sender B still gets through and is echoed.
+/// Catches cases where an in-flight per-source conn leaks state that
+/// blocks subsequent senders.
+#[tokio::test]
+async fn test_udp_forward_silent_target_doesnt_wedge_tunnel() {
+    timeout(TEST_TIMEOUT, async {
+        let server_port = get_available_port();
+        let local_port = get_available_udp_port();
+        let remote_port = get_available_udp_port();
+
+        let target = UdpSocket::bind(format!("127.0.0.1:{remote_port}"))
+            .await
+            .unwrap();
+        // Drop the first packet, echo every subsequent one.
+        let target_handle = tokio::spawn(async move {
+            let mut buf = vec![0u8; 2048];
+            let (_n, _peer) = target.recv_from(&mut buf).await.unwrap();
+            // Intentionally do not reply.
+            loop {
+                match target.recv_from(&mut buf).await {
+                    Ok((n, peer)) => {
+                        let _ = target.send_to(&buf[..n], peer).await;
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let remote = RemoteRequest::from_str(&format!(
+            "127.0.0.1:{local_port}:127.0.0.1:{remote_port}/udp"
+        ))
+        .unwrap();
+        let _env = start_tunnel(server_port, false, vec![remote]).await;
+
+        let sender_a = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let sender_b = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let tunnel = format!("127.0.0.1:{local_port}");
+
+        // First datagram is silently dropped at the target.
+        sender_a.send_to(b"lost", &tunnel).await.unwrap();
+        // Tiny gap so the per-source conn is fully wired before the next
+        // sender shows up — we want to test concurrent state, not race
+        // the conn-creation path.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        sender_b.send_to(b"alive", &tunnel).await.unwrap();
+        let mut buf = vec![0u8; 64];
+        let n = timeout(Duration::from_secs(5), sender_b.recv(&mut buf))
+            .await
+            .expect("a silent first sender wedged the tunnel for later senders")
+            .unwrap();
+        assert_eq!(&buf[..n], b"alive");
+
+        target_handle.abort();
+    })
+    .await
+    .expect("test_udp_forward_silent_target_doesnt_wedge_tunnel timed out");
+}


### PR DESCRIPTION
`tunnel_tcp_stream` ran the two copy directions inside `tokio::join!` to preserve buffered bytes during graceful half-close, but had no error-path bridge between them: on a hard error in one direction (peer RST, kernel-level disconnect), the failing future returned Err while its `SendStream` lived on in the outer scope, and the other direction kept blocking on a QUIC read that would never produce data. The function couldn't return until both halves finished, so the local `tcp_send` write half wasn't dropped either — no FIN to the local socket. Everything sat wedged until QUIC's ~30 s idle timeout reaped the connection.

Fix: keep `join!` for the graceful path (EOF → `shutdown().await`, unchanged), but on a hard error in either direction explicitly (1) reset that direction's `SendStream` so the peer's `RecvStream` errors immediately, (2) fire a shared `Notify` so the other local direction's `select!` exits its blocking read, and (3) the unblocked direction calls `tcp_send.shutdown()` so the local TCP peer sees a FIN. Both ends run the same code, so the reset chain propagates across the QUIC connection without either side needing originator knowledge. `biased` ordering on the `select!` guarantees the Notify waiter is registered before the copy is polled.

Also adds five new integration test files covering proxy semantics that were previously uncovered:

- tests/half_close.rs — target-initiated half-close (forward), reverse half-close in both directions, SOCKS5 forward half-close.
- tests/abrupt_close.rs — RST mid-stream from target/originator on forward and reverse paths, plus reverse dead-target. The three RST tests are the regression targets the fix above unblocks.
- tests/multi_client.rs — two clients sharing one server, plus isolation when one client disconnects.
- tests/udp_semantics.rs — per-sender response routing, oversized datagram framing, silent target doesn't wedge the tunnel.
- tests/concurrent.rs — per-connection failure isolation under multiplexing (one stream RST'd, siblings continue cleanly).
- tests/disconnect_cleanup.rs — reverse UDP socket and reverse SOCKS listener cleanup on client disconnect, mirroring the existing reverse-TCP listener cleanup test.

Suite goes from 109 to 124 tests; all green.