### PR TITLE
Add stdio remotes, drop R/, log to stderr (v0.8.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,55 @@ All notable changes to this project are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.1] - 2026-05-05
+## [0.8.2] - 2026-05-05
+
+Remote-syntax parity pass with chisel. Adds `stdio:` forward remotes and
+drops the Rusnel-specific `R/` reverse-prefix shorthand.
+
+### Added
+
+- **`stdio:<host>:<port>` and `stdio:<port>` remote syntax.** The client
+  pipes its own stdin/stdout to/from the tunnel instead of binding a
+  local listener, and exits cleanly when stdin EOFs. Useful as a
+  drop-in `ssh -o ProxyCommand` target. Forward-only — `R:stdio:…` is
+  rejected at parse time, as is `stdio:socks` (stdio is single-conn,
+  socks is dynamic). Server-side dispatch is unchanged: the remote
+  side still sees a normal TCP/UDP `connect`. Adds a `stdio: bool`
+  field to `RemoteRequest`; serialized with `#[serde(default)]` so old
+  control-plane payloads decode unchanged.
+- **`RemoteRequest::is_stdio()`** helper for the new field.
+
+### Changed
+
+- **Logs now go to stderr instead of stdout** (`server`, `client`,
+  `cert`, and `ctl` modes). CLI-tool convention, and a hard
+  requirement for forward `stdio:` remotes — the data plane on stdio
+  pipes the process's stdout to the tunnel, so any byte we emit on
+  stdout would have corrupted the peer's view of the stream.
+  Operators piping logs to a file or analyzer should adjust their
+  redirects (`2>` instead of `>` / `|`).
+
+### Removed
+
+- **`R/` reverse-prefix shorthand.** Chisel only accepts `R:`, and we
+  now match that exactly. `R/foo` is now a parse error. Use `R:foo`.
+
+### Tests
+
+- Twelve new parser unit tests in `src/common/remote.rs`: stdio with
+  host:port, port-only (defaulting remote to 127.0.0.1), `/udp`
+  suffix, IPv6 remote; rejection of `R:stdio:…`, bare `stdio`, and
+  `stdio:socks`; rejection of `R/`, bare `R`, and `R:` with empty
+  remainder; trailing-colon error path; IDN host pass-through;
+  `Display` round-trip for stdio.
+- New e2e smoke test (`tests/stdio.rs`) that spawns the actual
+  `rusnel` binary with `stdio:127.0.0.1:<echo>`, pipes three framed
+  messages through the child's stdin/stdout against an in-process
+  server + echo target, then drops stdin and asserts the child exits
+  zero. Exercises CLI parsing, session hello, the stdio data plane,
+  and the EOF-driven shutdown path end-to-end.
+
+
 
 Bug fix and integration-test expansion. The TCP tunnel now propagates
 hard errors (peer RST, abortive close mid-stream) across the QUIC

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "rusnel"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusnel"
 description = "Rusnel is a fast TCP/UDP tunnel, transported over and encrypted using QUIC protocol. Single executable including both client and server"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/guyte149/Rusnel"

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Arguments:
                        [::1]:80
                        [::1]:5000:[2001:db8::1]:80
                        R:[::1]:2222:[::1]:22
+                       stdio:example.com:22
 
                    IPv6 literals must be wrapped in [brackets] (same
                    convention as URLs and ssh -L).
@@ -127,6 +128,11 @@ Arguments:
 
                    Remotes can specify "socks" in place of remote-host and remote-port.
                    The default local host and port for a "socks" remote is 127.0.0.1:1080.
+
+                   Remotes can specify "stdio" in place of <local-host>:<local-port>
+                   to pipe the client process's stdin/stdout to/from the tunnel
+                   instead of binding a local listener. Stdio remotes are
+                   forward-only.
 
 
 Options:

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -17,7 +17,7 @@ use crate::common::remote::{
     Direction, DynamicTarget, OpenConnResponse, RemoteKind, RemoteRequest, SessionHello,
 };
 use crate::common::socks::tunnel_socks_client;
-use crate::common::tcp::{tunnel_tcp_client, tunnel_tcp_server};
+use crate::common::tcp::{tunnel_stdio_client, tunnel_tcp_client, tunnel_tcp_server};
 use crate::common::tunnel::{client_send_session_hello, receive_open_conn, reply_open_conn};
 use crate::common::udp::{tunnel_udp_client, tunnel_udp_server};
 use crate::{ClientConfig, ReconnectConfig};
@@ -363,11 +363,20 @@ async fn run_connection(
         let remote = remote.clone();
         let connection_clone = connection.clone();
         let span = info_span!("tunnel", tunnel_id = tunnel_id, remote = %remote);
+        // Stdio tunnels are single-shot: when stdin EOFs (or the
+        // remote end closes), the user expects the whole client to
+        // exit cleanly — not silently keep running with no input. We
+        // hand the stdio task a shutdown handle so it can fire that
+        // signal itself when it returns.
+        let shutdown_for_task = remote.is_stdio().then(|| shutdown_tx.clone());
 
         let task = task::spawn(
             async move {
                 if let Err(e) = handle_forward_tunnel(connection_clone, remote, tunnel_id).await {
                     error!("failed: {}", e)
+                }
+                if let Some(tx) = shutdown_for_task {
+                    let _ = tx.send(());
                 }
                 anyhow::Ok(())
             }
@@ -446,6 +455,13 @@ async fn handle_forward_tunnel(
     remote: RemoteRequest,
     tunnel_id: u64,
 ) -> Result<()> {
+    // Stdio short-circuits the listener-bind path: there is no local
+    // socket to accept on, just a single bi-stream wired to the
+    // process's stdin/stdout. The server-side dispatch is unchanged
+    // (it sees a normal Tcp/Udp tunnel via the OpenConn frame).
+    if remote.is_stdio() {
+        return tunnel_stdio_client(quic_connection, tunnel_id).await;
+    }
     match &remote.kind {
         RemoteKind::Socks5 { .. } => {
             tunnel_socks_client(quic_connection, remote, None, tunnel_id).await?
@@ -553,37 +569,37 @@ fn resolve_reverse_dispatch(
         ));
     }
     match (&parent.kind, dynamic) {
-        (RemoteKind::Tcp { local, remote }, None) => Ok(ReverseDispatch::Tcp(RemoteRequest {
-            direction: Direction::Reverse,
-            kind: RemoteKind::Tcp {
+        (RemoteKind::Tcp { local, remote }, None) => Ok(ReverseDispatch::Tcp(RemoteRequest::new(
+            Direction::Reverse,
+            RemoteKind::Tcp {
                 local: *local,
                 remote: remote.clone(),
             },
-        })),
-        (RemoteKind::Udp { local, remote }, None) => Ok(ReverseDispatch::Udp(RemoteRequest {
-            direction: Direction::Reverse,
-            kind: RemoteKind::Udp {
+        ))),
+        (RemoteKind::Udp { local, remote }, None) => Ok(ReverseDispatch::Udp(RemoteRequest::new(
+            Direction::Reverse,
+            RemoteKind::Udp {
                 local: *local,
                 remote: remote.clone(),
             },
-        })),
+        ))),
         (RemoteKind::Socks5 { local }, Some(DynamicTarget::Tcp(target))) => {
-            Ok(ReverseDispatch::Tcp(RemoteRequest {
-                direction: Direction::Reverse,
-                kind: RemoteKind::Tcp {
+            Ok(ReverseDispatch::Tcp(RemoteRequest::new(
+                Direction::Reverse,
+                RemoteKind::Tcp {
                     local: *local,
                     remote: target,
                 },
-            }))
+            )))
         }
         (RemoteKind::Socks5 { local }, Some(DynamicTarget::Udp(target))) => {
-            Ok(ReverseDispatch::Udp(RemoteRequest {
-                direction: Direction::Reverse,
-                kind: RemoteKind::Udp {
+            Ok(ReverseDispatch::Udp(RemoteRequest::new(
+                Direction::Reverse,
+                RemoteKind::Udp {
                     local: *local,
                     remote: target,
                 },
-            }))
+            )))
         }
         (RemoteKind::Socks5 { .. }, None) => Err(anyhow!(
             "server pushed reverse SOCKS5 conn without a dynamic target"

--- a/src/common/remote.rs
+++ b/src/common/remote.rs
@@ -98,11 +98,22 @@ impl RemoteKind {
 pub struct RemoteRequest {
     pub direction: Direction,
     pub kind: RemoteKind,
+    /// `true` when the user typed `stdio:host:port` (forward-only). The
+    /// client pipes its own stdin/stdout to/from the QUIC stream instead
+    /// of binding a local listener; the server side is unaffected (still
+    /// a normal TCP/UDP `connect` to `kind.remote`). The dummy
+    /// `kind.local` (always `0.0.0.0:0`) is never bound.
+    #[serde(default)]
+    pub stdio: bool,
 }
 
 impl RemoteRequest {
     pub fn new(direction: Direction, kind: RemoteKind) -> Self {
-        Self { direction, kind }
+        Self {
+            direction,
+            kind,
+            stdio: false,
+        }
     }
 
     /// `true` if this remote represents SOCKS5 traffic — a standalone
@@ -119,6 +130,10 @@ impl RemoteRequest {
 
     pub fn is_reversed(&self) -> bool {
         matches!(self.direction, Direction::Reverse)
+    }
+
+    pub fn is_stdio(&self) -> bool {
+        self.stdio
     }
 
     /// `local_host:local_port` as a `SocketAddr`. Use the resulting value's
@@ -154,6 +169,20 @@ impl fmt::Display for RemoteRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_reversed() {
             write!(f, "R:")?;
+        }
+        if self.stdio {
+            // stdio is always forward-only (rejected at parse time
+            // otherwise) and is forbidden with SOCKS5, so the only
+            // shapes here are Tcp/Udp.
+            return match &self.kind {
+                RemoteKind::Tcp { remote, .. } => {
+                    write!(f, "stdio=>{}/tcp", remote.to_addr_string())
+                }
+                RemoteKind::Udp { remote, .. } => {
+                    write!(f, "stdio=>{}/udp", remote.to_addr_string())
+                }
+                RemoteKind::Socks5 { .. } => write!(f, "stdio=>socks"),
+            };
         }
         match &self.kind {
             RemoteKind::Socks5 { local } => write!(f, "{}=>socks", local.port()),
@@ -242,12 +271,21 @@ impl SerdeHelper for OpenConnResponse {}
 /// request a SOCKS5 dynamic tunnel.
 const SOCKS_KEYWORD: &str = "socks";
 
+/// Marker token that replaces the local-side `host:port` to request that
+/// the client pipe its own stdin/stdout to/from the tunnel instead of
+/// binding a local listener. Forward-only — `R:stdio:...` is rejected.
+const STDIO_KEYWORD: &str = "stdio";
+
 /// Default address for things that historically defaulted to `0.0.0.0` (the
 /// IPv4 wildcard).
 const ANY_V4: &str = "0.0.0.0";
 /// Default address for SOCKS5's local listener.
 const SOCKS_DEFAULT_LOCAL: &str = "127.0.0.1";
 const SOCKS_DEFAULT_PORT: u16 = 1080;
+/// Default `remote_host` used when the user omits it in a `stdio:port`
+/// short-hand, matching chisel's behavior (`3000` resolves to
+/// `127.0.0.1:3000` on the remote side).
+const STDIO_DEFAULT_REMOTE_HOST: &str = "127.0.0.1";
 
 /// Decomposed input as a sequence of structured layers. The parser pipes the
 /// raw string through these sub-parses in order:
@@ -265,26 +303,45 @@ impl FromStr for RemoteRequest {
         let (direction, after_dir) = parse_direction(input)?;
         let (protocol_hint, body) = parse_protocol(after_dir)?;
         let tokens = split_addr_tokens(body)?;
-        let kind = tokens_to_kind(&tokens, protocol_hint)?;
-        Ok(RemoteRequest { direction, kind })
+
+        // Detect a leading `stdio` token. Stdio replaces the local
+        // listener with the client's own stdin/stdout, so it only
+        // makes sense in the *first* token slot and only on forward
+        // tunnels (the server side of a reverse tunnel can't write to
+        // the client's stdout).
+        let (stdio, addr_tokens) = if !tokens.is_empty() && tokens[0] == STDIO_KEYWORD {
+            if matches!(direction, Direction::Reverse) {
+                return Err(anyhow!("Invalid format: stdio cannot be reversed"));
+            }
+            (true, &tokens[1..])
+        } else {
+            (false, tokens.as_slice())
+        };
+
+        let kind = if stdio {
+            tokens_to_stdio_kind(addr_tokens, protocol_hint)?
+        } else {
+            tokens_to_kind(addr_tokens, protocol_hint)?
+        };
+        Ok(RemoteRequest {
+            direction,
+            kind,
+            stdio,
+        })
     }
 }
 
-/// Strip a leading `R:` / `R/` ("reverse") marker. Both forms are accepted
-/// for backwards compatibility — the chisel CLI documented the colon form;
-/// the slash form fell out of `R/protocol` parsing in earlier versions.
+/// Strip a leading `R:` ("reverse") marker. Matches chisel's syntax exactly:
+/// the colon form is the only form accepted.
 fn parse_direction(s: &str) -> Result<(Direction, &str)> {
     if let Some(rest) = s.strip_prefix("R:") {
+        if rest.is_empty() {
+            return Err(anyhow!("Invalid format: Missing details after R:"));
+        }
         return Ok((Direction::Reverse, rest));
     }
     if s == "R" {
         return Err(anyhow!("Invalid format: Missing details after R"));
-    }
-    if let Some(rest) = s.strip_prefix("R/") {
-        if rest.is_empty() {
-            return Err(anyhow!("Invalid format: Missing details after R"));
-        }
-        return Ok((Direction::Reverse, rest));
     }
     Ok((Direction::Forward, s))
 }
@@ -462,6 +519,46 @@ fn parse_four_tokens(tokens: &[&str], protocol: Option<Protocol>) -> Result<Remo
         HostPort::new(remote_host, remote_port),
         protocol,
     ))
+}
+
+/// Build a [`RemoteKind`] for a `stdio:...` declaration. The `local`
+/// `SocketAddr` is a dummy `0.0.0.0:0` — the client's stdio dispatcher
+/// never binds it. Stdio is incompatible with SOCKS5 (no `socks` keyword
+/// allowed in the remainder) since stdio is a single-conn pipe.
+fn tokens_to_stdio_kind(tokens: &[&str], protocol: Option<Protocol>) -> Result<RemoteKind> {
+    if tokens.contains(&SOCKS_KEYWORD) {
+        return Err(anyhow!(
+            "Invalid format: stdio cannot be combined with socks"
+        ));
+    }
+    let local = SocketAddr::new(any_v4(), 0);
+    match tokens.len() {
+        1 => {
+            // `stdio:<port>` — chisel defaults the omitted remote host
+            // to 127.0.0.1 (vs. 0.0.0.0 for a bare port short-hand).
+            let port = parse_port(tokens[0], "remote port")?;
+            Ok(make_host_port_kind(
+                local,
+                HostPort::new(STDIO_DEFAULT_REMOTE_HOST, port),
+                protocol,
+            ))
+        }
+        2 => {
+            let remote_host = unbracket(tokens[0]).to_string();
+            let remote_port = parse_port(tokens[1], "remote port")?;
+            Ok(make_host_port_kind(
+                local,
+                HostPort::new(remote_host, remote_port),
+                protocol,
+            ))
+        }
+        0 => Err(anyhow!(
+            "Invalid format: stdio requires a remote host:port or port"
+        )),
+        _ => Err(anyhow!(
+            "Invalid format: stdio expects '<host>:<port>' or '<port>'"
+        )),
+    }
 }
 
 fn make_host_port_kind(
@@ -735,5 +832,128 @@ mod tests {
         assert_eq!(parse("80").kind.protocol(), Some(Protocol::Tcp));
         assert_eq!(parse("80/udp").kind.protocol(), Some(Protocol::Udp));
         assert_eq!(parse("socks").kind.protocol(), None);
+    }
+
+    #[test]
+    fn rejects_r_slash_prefix() {
+        // `R/` was a Rusnel-specific shorthand; we now match chisel
+        // exactly and require the colon form.
+        let err = RemoteRequest::from_str("R/1337:google.com:80").unwrap_err();
+        assert!(
+            err.to_string().contains("Invalid"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_bare_r() {
+        let err = RemoteRequest::from_str("R").unwrap_err();
+        assert!(
+            err.to_string().contains("after R"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_after_reverse_prefix() {
+        let err = RemoteRequest::from_str("R:").unwrap_err();
+        assert!(
+            err.to_string().contains("after R:"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn stdio_with_remote_host_port() {
+        let r = parse("stdio:example.com:22");
+        assert!(r.is_stdio());
+        assert!(!r.is_reversed());
+        let (_, remote, proto) = unwrap_hp(&r);
+        assert_eq!(remote.host, "example.com");
+        assert_eq!(remote.port, 22);
+        assert_eq!(proto, Protocol::Tcp);
+    }
+
+    #[test]
+    fn stdio_with_just_port_defaults_remote_to_loopback() {
+        // Per chisel's `stdio:80` short-hand: omitted remote host
+        // resolves to 127.0.0.1 (not 0.0.0.0).
+        let r = parse("stdio:80");
+        assert!(r.is_stdio());
+        let (_, remote, _) = unwrap_hp(&r);
+        assert_eq!(remote.host, "127.0.0.1");
+        assert_eq!(remote.port, 80);
+    }
+
+    #[test]
+    fn stdio_with_udp_protocol_suffix() {
+        let r = parse("stdio:1.1.1.1:53/udp");
+        assert!(r.is_stdio());
+        let (_, remote, proto) = unwrap_hp(&r);
+        assert_eq!(remote.host, "1.1.1.1");
+        assert_eq!(remote.port, 53);
+        assert_eq!(proto, Protocol::Udp);
+    }
+
+    #[test]
+    fn stdio_ipv6_remote() {
+        let r = parse("stdio:[2001:db8::1]:443");
+        assert!(r.is_stdio());
+        let (_, remote, _) = unwrap_hp(&r);
+        assert_eq!(remote.host, "2001:db8::1");
+        assert_eq!(remote.port, 443);
+    }
+
+    #[test]
+    fn rejects_reverse_stdio() {
+        let err = RemoteRequest::from_str("R:stdio:example.com:22").unwrap_err();
+        assert!(
+            err.to_string().contains("stdio cannot be reversed"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_stdio_alone() {
+        let err = RemoteRequest::from_str("stdio").unwrap_err();
+        assert!(
+            err.to_string().contains("stdio requires"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_stdio_socks() {
+        let err = RemoteRequest::from_str("stdio:socks").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("stdio cannot be combined with socks"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn stdio_round_trips_through_display() {
+        let r = parse("stdio:example.com:22");
+        assert_eq!(r.to_string(), "stdio=>example.com:22/tcp");
+        let r = parse("stdio:1.1.1.1:53/udp");
+        assert_eq!(r.to_string(), "stdio=>1.1.1.1:53/udp");
+    }
+
+    #[test]
+    fn rejects_trailing_colon() {
+        let err = RemoteRequest::from_str("1.1.1.1:").unwrap_err();
+        assert!(
+            err.to_string().contains("trailing ':'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn idn_remote_host_passes_through() {
+        let r = parse("示例網站.com:80");
+        let (_, remote, _) = unwrap_hp(&r);
+        assert_eq!(remote.host, "示例網站.com");
+        assert_eq!(remote.port, 80);
     }
 }

--- a/src/common/tcp.rs
+++ b/src/common/tcp.rs
@@ -216,6 +216,101 @@ enum CopyOutcome {
     AbortedWith(std::io::Error),
 }
 
+/// Forward-stdio tunnel: open a single bi-stream, announce it with an
+/// [`OpenConn`] keyed by `tunnel_id`, then pipe the *client process's*
+/// stdin/stdout to/from that stream. Returns when either side closes,
+/// at which point the caller is expected to tear the QUIC session down
+/// (stdio is single-shot — there is no listen-loop to come back to).
+///
+/// Only used for forward tunnels: `R:stdio:...` is rejected at parse
+/// time. SOCKS5 stdio is likewise rejected — stdio is a single conn,
+/// SOCKS is many.
+pub async fn tunnel_stdio_client(quic_connection: Connection, tunnel_id: u64) -> Result<()> {
+    use crate::common::tunnel::send_open_conn;
+
+    debug!("opening stdio tunnel");
+    let (mut send, mut recv) = quic_connection.open_bi().await?;
+    send_open_conn(
+        &OpenConn {
+            tunnel_id,
+            dynamic: None,
+        },
+        &mut send,
+        &mut recv,
+    )
+    .await?;
+    info!("stdio tunnel ready (piping stdin/stdout)");
+
+    let mut stdin = BufReader::with_capacity(TUNNEL_COPY_BUF, tokio::io::stdin());
+    let mut stdout = tokio::io::stdout();
+    let mut quic_recv = BufReader::with_capacity(TUNNEL_COPY_BUF, recv);
+
+    let abort: Arc<Notify> = Arc::new(Notify::new());
+    const ABORT_CODE: u32 = 0;
+
+    let stdin_to_quic = {
+        let abort = abort.clone();
+        async move {
+            let outcome = tokio::select! {
+                biased;
+                _ = abort.notified() => CopyOutcome::Aborted,
+                r = tokio::io::copy_buf(&mut stdin, &mut send) => match r {
+                    Ok(_) => CopyOutcome::Eof,
+                    Err(e) => CopyOutcome::Errored(e),
+                },
+            };
+            match outcome {
+                CopyOutcome::Eof => {
+                    let _ = send.shutdown().await;
+                    Ok(())
+                }
+                CopyOutcome::Errored(e) | CopyOutcome::AbortedWith(e) => {
+                    let _ = send.reset(VarInt::from_u32(ABORT_CODE));
+                    abort.notify_waiters();
+                    Err(anyhow::Error::from(e))
+                }
+                CopyOutcome::Aborted => {
+                    let _ = send.reset(VarInt::from_u32(ABORT_CODE));
+                    Ok(())
+                }
+            }
+        }
+    };
+
+    let quic_to_stdout = {
+        let abort = abort.clone();
+        async move {
+            let outcome = tokio::select! {
+                biased;
+                _ = abort.notified() => CopyOutcome::Aborted,
+                r = tokio::io::copy_buf(&mut quic_recv, &mut stdout) => match r {
+                    Ok(_) => CopyOutcome::Eof,
+                    Err(e) => CopyOutcome::Errored(e),
+                },
+            };
+            // Flush stdout best-effort regardless of outcome — the
+            // user wants to see whatever bytes made it before EOF.
+            let _ = stdout.flush().await;
+            match outcome {
+                CopyOutcome::Eof => Ok(()),
+                CopyOutcome::Errored(e) | CopyOutcome::AbortedWith(e) => {
+                    abort.notify_waiters();
+                    Err(anyhow::Error::from(e))
+                }
+                CopyOutcome::Aborted => Ok(()),
+            }
+        }
+    };
+
+    let (s2q, q2s) = tokio::join!(stdin_to_quic, quic_to_stdout);
+    match (&s2q, &q2s) {
+        (Ok(_), Ok(_)) => debug!("stdio tunnel closed"),
+        (Err(e), _) => debug!("stdin→quic error: {}", e),
+        (_, Err(e)) => debug!("quic→stdout error: {}", e),
+    }
+    Ok(())
+}
+
 pub async fn tunnel_tcp_client(
     quic_connection: Connection,
     remote: RemoteRequest,

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,6 +310,7 @@ sharing <remote-host>:<remote-port> from the client to the server\'s <local-host
         1.1.1.1:53/udp
         [::1]:80
         [::1]:5000:[2001:db8::1]:80
+        stdio:example.com:22
 
     IPv6 literals must be wrapped in [brackets] (same convention as URLs and ssh -L).
 
@@ -317,6 +318,11 @@ sharing <remote-host>:<remote-port> from the client to the server\'s <local-host
 
     Remotes can specify "socks" in place of remote-host and remote-port.
     The default local host and port for a "socks" remote is 127.0.0.1:1080.
+
+    Remotes can specify "stdio" in place of <local-host>:<local-port> to pipe
+    the client process's stdin/stdout to/from the tunnel instead of binding a
+    local listener (useful as an `ssh -o ProxyCommand` target). Stdio remotes
+    are forward-only.
         "#)]
         remotes: Vec<RemoteRequest>,
 
@@ -826,6 +832,7 @@ fn main() {
                 .with_max_level(tracing::Level::WARN)
                 .with_target(false)
                 .without_time()
+                .with_writer(std::io::stderr)
                 .init();
             let socket_path = socket.unwrap_or_else(rusnel::ctl::default_socket_path);
             if let Err(e) = run_ctl(&socket_path, json, action) {
@@ -840,6 +847,7 @@ fn main() {
                 .with_max_level(tracing::Level::INFO)
                 .with_target(false)
                 .without_time()
+                .with_writer(std::io::stderr)
                 .init();
             if let Err(e) = run_cert(action) {
                 Args::command()
@@ -981,7 +989,14 @@ fn set_log_level(is_verbose: bool, is_debug: bool) {
     } else {
         tracing::Level::INFO
     };
-    tracing_subscriber::fmt().with_max_level(log_level).init();
+    // Log to stderr, not stdout. CLI-tool convention, and a hard
+    // requirement for forward `stdio:` remotes — those pipe the
+    // process's stdout to the tunnel, so any byte we emit on stdout
+    // becomes part of the data stream and corrupts the peer's view.
+    tracing_subscriber::fmt()
+        .with_max_level(log_level)
+        .with_writer(std::io::stderr)
+        .init();
 
     debug!("log level: {}", log_level);
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -363,10 +363,7 @@ fn spawn_reverse_handler(
             // declaration so the existing handlers (which still take a
             // `RemoteRequest` for local-bind / target lookup) keep
             // working unchanged.
-            let request = RemoteRequest {
-                direction: tunnel.direction,
-                kind: tunnel.kind.clone(),
-            };
+            let request = RemoteRequest::new(tunnel.direction, tunnel.kind.clone());
             let result = match &tunnel.kind {
                 RemoteKind::Tcp { .. } => {
                     tunnel_tcp_client(connection, request, Some(handle), tunnel.id).await
@@ -473,37 +470,37 @@ fn resolve_dispatch(
         ));
     }
     match (&tunnel.kind, dynamic) {
-        (RemoteKind::Tcp { local, remote }, None) => Ok(ForwardDispatch::Tcp(RemoteRequest {
-            direction: Direction::Forward,
-            kind: RemoteKind::Tcp {
+        (RemoteKind::Tcp { local, remote }, None) => Ok(ForwardDispatch::Tcp(RemoteRequest::new(
+            Direction::Forward,
+            RemoteKind::Tcp {
                 local: *local,
                 remote: remote.clone(),
             },
-        })),
-        (RemoteKind::Udp { local, remote }, None) => Ok(ForwardDispatch::Udp(RemoteRequest {
-            direction: Direction::Forward,
-            kind: RemoteKind::Udp {
+        ))),
+        (RemoteKind::Udp { local, remote }, None) => Ok(ForwardDispatch::Udp(RemoteRequest::new(
+            Direction::Forward,
+            RemoteKind::Udp {
                 local: *local,
                 remote: remote.clone(),
             },
-        })),
+        ))),
         (RemoteKind::Socks5 { local }, Some(DynamicTarget::Tcp(target))) => {
-            Ok(ForwardDispatch::Tcp(RemoteRequest {
-                direction: Direction::Forward,
-                kind: RemoteKind::Tcp {
+            Ok(ForwardDispatch::Tcp(RemoteRequest::new(
+                Direction::Forward,
+                RemoteKind::Tcp {
                     local: *local,
                     remote: target.clone(),
                 },
-            }))
+            )))
         }
         (RemoteKind::Socks5 { local }, Some(DynamicTarget::Udp(target))) => {
-            Ok(ForwardDispatch::Udp(RemoteRequest {
-                direction: Direction::Forward,
-                kind: RemoteKind::Udp {
+            Ok(ForwardDispatch::Udp(RemoteRequest::new(
+                Direction::Forward,
+                RemoteKind::Udp {
                     local: *local,
                     remote: target.clone(),
                 },
-            }))
+            )))
         }
         (RemoteKind::Socks5 { .. }, None) => Err(anyhow::anyhow!(
             "OpenConn on SOCKS5 tunnel {} requires a `dynamic` target",

--- a/tests/reconnect.rs
+++ b/tests/reconnect.rs
@@ -180,10 +180,9 @@ async fn run_test_session(connection: Connection) {
             }
             // Only forward TCP is exercised by this test stub.
             let req = match parent.kind {
-                RemoteKind::Tcp { local, remote } => RemoteRequest {
-                    direction: Direction::Forward,
-                    kind: RemoteKind::Tcp { local, remote },
-                },
+                RemoteKind::Tcp { local, remote } => {
+                    RemoteRequest::new(Direction::Forward, RemoteKind::Tcp { local, remote })
+                }
                 _ => return,
             };
             if let Err(e) = tunnel_tcp_server(recv, send, req, None).await {

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -1,0 +1,141 @@
+//! End-to-end smoke test for `stdio:` forward remotes.
+//!
+//! The stdio data path can't be exercised in-process — `tunnel_stdio_client`
+//! reads from `tokio::io::stdin()` / writes to `tokio::io::stdout()`, both of
+//! which are process-global handles. So this test spawns the actual `rusnel`
+//! binary as a subprocess (cargo exposes its path via `CARGO_BIN_EXE_rusnel`
+//! at integration-test compile time), points it at an in-process server +
+//! echo target, and pipes payload through the child's stdin/stdout.
+//!
+//! Verifies three things in one shot:
+//!   1. `stdio:host:port` parses + dispatches end-to-end (CLI → session
+//!      hello → server-side TCP connect to the echo target).
+//!   2. Bytes flow bidirectionally over the QUIC stream piped to/from the
+//!      child's stdio.
+//!   3. Closing the child's stdin (EOF) drives a clean shutdown of the
+//!      whole client — the process exits 0 instead of hanging.
+
+mod common;
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use common::{get_available_port, init_crypto, server_config};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+/// Bound for *any* await in this test. Generous (10s) because the child
+/// has to: build nothing (cargo prebuilds the bin), exec, do a QUIC
+/// handshake against `--insecure`, send the session hello, and only then
+/// open the stdio bi-stream. On a cold CI runner the handshake alone can
+/// take a few hundred ms.
+const STEP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Tiny TCP echo server: accept once, echo bytes until the peer half-closes,
+/// then drop. Returns the listener's address. The accept loop runs in a
+/// background task that owns the listener for the lifetime of the test.
+async fn spawn_echo_server() -> std::net::SocketAddr {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        // One accept is enough — stdio is single-conn by design.
+        let (mut sock, _) = listener.accept().await.unwrap();
+        let (mut r, mut w) = sock.split();
+        let _ = tokio::io::copy(&mut r, &mut w).await;
+        let _ = w.shutdown().await;
+    });
+    addr
+}
+
+#[tokio::test]
+async fn stdio_forward_pipes_stdin_stdout_through_tunnel() {
+    init_crypto();
+
+    let server_port = get_available_port();
+    let echo_addr = spawn_echo_server().await;
+
+    // In-process server. We only need the server half — the client is
+    // the subprocess we spawn below — so we can't reuse `start_tunnel`
+    // (which spawns both).
+    let sc = server_config(server_port, false);
+    let server_handle = tokio::spawn(async move {
+        let _ = rusnel::server::run_async(sc).await;
+    });
+    // Same delay `start_tunnel` uses for the QUIC listener to come up.
+    tokio::time::sleep(common::STARTUP_DELAY).await;
+
+    let bin = env!("CARGO_BIN_EXE_rusnel");
+    let server_url = format!("127.0.0.1:{server_port}");
+    let stdio_remote = format!("stdio:127.0.0.1:{}", echo_addr.port());
+
+    let mut child = Command::new(bin)
+        .args([
+            "client",
+            "--insecure",
+            // Cap reconnects: a stdio client is single-shot. `0` means
+            // "no retries" — the process exits once the session ends.
+            "--max-retry-count",
+            "0",
+            &server_url,
+            &stdio_remote,
+        ])
+        // Inherit stderr so test logs are visible on failure; capture
+        // stdin/stdout — those are the tunnel.
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("failed to spawn rusnel client subprocess");
+
+    let mut stdin = child.stdin.take().expect("captured stdin");
+    let stdout = child.stdout.take().expect("captured stdout");
+    let mut reader = BufReader::new(stdout);
+
+    // Round-trip a few framed messages through the echo. Use newline
+    // framing so we can read line-by-line without guessing chunk
+    // boundaries — quinn may coalesce or split writes.
+    let messages = ["hello\n", "stdio tunnel\n", "third frame\n"];
+    for msg in messages {
+        timeout(STEP_TIMEOUT, stdin.write_all(msg.as_bytes()))
+            .await
+            .expect("write to child stdin timed out")
+            .expect("write to child stdin failed");
+        timeout(STEP_TIMEOUT, stdin.flush())
+            .await
+            .expect("flush child stdin timed out")
+            .expect("flush child stdin failed");
+
+        let mut got = String::new();
+        timeout(STEP_TIMEOUT, reader.read_line(&mut got))
+            .await
+            .expect("read from child stdout timed out")
+            .expect("read from child stdout failed");
+        assert_eq!(got, msg, "echo mismatch (sent vs got)");
+    }
+
+    // Drop stdin: this should propagate EOF through the tunnel, the echo
+    // server shuts its write half, the child's stdout reader sees EOF,
+    // the stdio task fires the shutdown signal, and the client exits 0.
+    drop(stdin);
+
+    // Drain anything still buffered in stdout so the child's quic→stdout
+    // copy can complete cleanly (without this read, the child can block
+    // on `stdout.write_all` if the echo server flushed bytes after our
+    // last read).
+    let mut tail = Vec::new();
+    let _ = timeout(STEP_TIMEOUT, reader.read_to_end(&mut tail)).await;
+
+    let status = timeout(STEP_TIMEOUT, child.wait())
+        .await
+        .expect("child did not exit after stdin EOF")
+        .expect("child wait failed");
+    assert!(
+        status.success(),
+        "rusnel client exited with non-zero status: {status:?}"
+    );
+
+    server_handle.abort();
+}


### PR DESCRIPTION
Three changes that bring the remote-syntax parser to chisel parity and make `stdio:` remotes actually usable:

- Add `stdio:<host>:<port>` (and `stdio:<port>`, defaulting remote host to 127.0.0.1) forward remotes. The client pipes its own stdin/stdout to/from the QUIC stream instead of binding a local listener; on stdin EOF the session shuts down cleanly. Server-side dispatch is unchanged. Reverse stdio (`R:stdio:...`) and `stdio:socks` are rejected at parse time. Wire model: new `stdio: bool` on `RemoteRequest`, serialized with `#[serde(default)]`.

- Drop the Rusnel-specific `R/` reverse-prefix shorthand. Chisel only accepts `R:` and we now match exactly. `R/foo` is now a parse error.

- Initialize tracing with `with_writer(std::io::stderr)` for all CLI modes. Required for stdio (stdout is the data plane); good practice for the rest.

Tests: 12 new parser unit tests for the stdio + R/ changes, plus a new `tests/stdio.rs` e2e smoke that spawns the rusnel binary as a subprocess with a stdio remote pointing at an in-process echo target, round-trips three framed messages through its stdin/stdout, and asserts the child exits 0 after stdin EOF.