### PR TITLE
Production-grade structured logging (v0.9.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +857,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,6 +1191,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "rusnel"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1227,6 +1262,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "time",
  "tokio",
  "tower",
  "tracing",
@@ -1758,17 +1794,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "time",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusnel"
 description = "Rusnel is a fast TCP/UDP tunnel, transported over and encrypted using QUIC protocol. Single executable including both client and server"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/guyte149/Rusnel"
@@ -18,7 +18,8 @@ tokio = { version = "1.52.1", features = ["full"] }
 rcgen = { version = "0.14.7", features = ["x509-parser"] }
 rustls = { version = "0.23.40", features = ["ring"] }
 tracing = "0.1.44"
-tracing-subscriber = "0.3.23"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt", "ansi", "json", "time"] }
+time = { version = "0.3", features = ["formatting", "macros"] }
 rmp-serde = "1"
 serde = { version = "1.0.*", features = ["derive"] }
 anyhow = "1.0.102"

--- a/README.md
+++ b/README.md
@@ -317,6 +317,62 @@ resolved at build time via `include_bytes!` (the file no longer needs to exist
 on the deployment host); string-style vars are baked in as `&'static str`.
 See [`build.rs`](build.rs) for the full mapping.
 
+## Logging
+
+Rusnel uses [`tracing`](https://docs.rs/tracing) end-to-end with structured
+fields and stable span hierarchy.
+
+**Verbosity** (mutually exclusive):
+
+```bash
+rusnel server ...                  # INFO  (default)
+rusnel server -v ...               # DEBUG for rusnel modules
+rusnel server --debug ...          # TRACE for rusnel modules
+rusnel server -q / --quiet ...     # WARN-and-above only
+```
+
+For finer control set `RUST_LOG` directly — it overrides the flags:
+
+```bash
+RUST_LOG=rusnel=debug,quinn=info rusnel server ...
+RUST_LOG=rusnel::common::tcp=trace rusnel client ...
+```
+
+**Format**: human-readable compact (default) or one JSON object per line for
+log aggregators:
+
+```bash
+rusnel server --log-format json ...
+```
+
+Logs go to **stderr** (so forward `stdio:` tunnels can use stdout cleanly).
+Timestamps are ISO-8601 UTC with millisecond precision; ANSI colours are
+auto-detected from the stderr TTY.
+
+**Schema**. Every event is wrapped in spans whose field names match the
+`rusnel ctl` / admin-API ID schema, so logs grep cleanly against API output:
+
+| Span      | Fields                                  | Where                          |
+|-----------|-----------------------------------------|--------------------------------|
+| `client`  | `client_id`, `peer`                     | server, per QUIC session       |
+| `session` | `peer`                                  | client, per QUIC session       |
+| `tunnel`  | `tunnel_id`, `dir`, `spec`              | both, per declared remote      |
+| `conn`    | `conn_id`, `tunnel_id`, `peer`, `proto` | both, per data-plane stream    |
+
+Every conn emits a `conn opened` event on entry and a `conn closed` event on
+exit carrying `bytes_in`, `bytes_out`, and `dur_ms` — useful for ad-hoc
+"who used the most bytes" greps without standing up a metrics pipeline.
+
+Example session (compact format, ANSI stripped):
+
+```
+2026-05-05T11:03:55.022Z  INFO client: connected client_id=1 peer=127.0.0.1:62178
+2026-05-05T11:03:55.027Z  INFO client: session established count=1
+2026-05-05T11:03:55.027Z  INFO client: tunnel registered tunnel_id=1 dir="forward" spec=19999=>127.0.0.1:9999/tcp
+2026-05-05T11:03:55.670Z  INFO conn: conn opened conn_id=1 tunnel_id=1 peer="127.0.0.1:9999"
+2026-05-05T11:03:55.671Z  INFO conn: conn closed bytes_in=12 bytes_out=17 dur_ms=1
+```
+
 ## Performance
 
 Rusnel (QUIC) vs [Chisel](https://github.com/jpillora/chisel) (SSH-over-WebSocket)
@@ -343,7 +399,7 @@ the script adds for you). See [`benchmark/`](benchmark/) for tunables.
 ### Reliability & UX
 - [x] client reconnect with exponential backoff (configurable via `--max-retry-count` / `--max-retry-interval`)
 - [x] proxy support for client: `--proxy socks5://[user:pass@]host:port` routes the QUIC connection through a SOCKS5 proxy via UDP ASSOCIATE (RFC 1928 §4). HTTP CONNECT is intentionally not supported in this release because it cannot carry UDP — see the WebSocket-fallback transport item under `Security & access control` for the path that would unlock HTTP/SOCKS-CONNECT proxies.
-- [ ] `RUST_LOG`-style env filter for `tracing-subscriber` (per-module log levels)
+- [x] **production-grade structured logging**: `tracing-subscriber` with `EnvFilter` (`RUST_LOG=rusnel=debug,quinn=info`), `--quiet` / `-q`, `--log-format compact|json`, ISO-8601 UTC timestamps, ANSI colours auto-detected. Stable span hierarchy `client{client_id,peer}` → `tunnel{tunnel_id,dir,spec}` → `conn{conn_id,tunnel_id,peer}` (matching the `rusnel ctl` ID schema), and every conn emits a structured close summary with `bytes_in`, `bytes_out`, `dur_ms`. See "Logging" below.
 
 ### Protocol features
 - [ ] add fake-backend http/3 feature to server (real HTTP/3 facade for active probes that open streams)

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -30,7 +30,7 @@ pub async fn run_async(config: ClientConfig) -> Result<()> {
     let mut endpoints = match &config.proxy {
         None => Some(EndpointPool::new(&config)?),
         Some(p) => {
-            info!("routing QUIC through proxy: {p}");
+            info!(proxy = %p, "routing QUIC through SOCKS5 proxy");
             None
         }
     };
@@ -43,7 +43,7 @@ pub async fn run_async(config: ClientConfig) -> Result<()> {
     let shutdown_tx_clone = shutdown_tx.clone();
     tokio::spawn(async move {
         if signal::ctrl_c().await.is_ok() {
-            info!("Shutdown signal received. Broadcasting shutdown...");
+            info!("shutdown signal received");
             let _ = shutdown_tx_clone.send(());
         }
     });
@@ -53,7 +53,7 @@ pub async fn run_async(config: ClientConfig) -> Result<()> {
     if let Some(pool) = endpoints.as_ref() {
         pool.wait_idle().await;
     }
-    debug!("Run function completed");
+    debug!("client run loop exited");
     result
 }
 
@@ -145,10 +145,7 @@ async fn run_with_reconnect(
     loop {
         let mut shutdown_rx = shutdown_tx.subscribe();
 
-        info!(
-            "connecting to server at: {} (sni: {})",
-            config.server, server_name
-        );
+        info!(server = %config.server, sni = %server_name, "connecting");
 
         // Two connect strategies: direct (Happy Eyeballs across all resolved
         // addresses, sharing QUIC endpoints across attempts) or via SOCKS5
@@ -172,20 +169,24 @@ async fn run_with_reconnect(
 
         match connect_outcome {
             Some(Ok(connection)) => {
-                info!("Connected successfully");
+                let peer = connection.remote_address();
+                info!(peer = %peer, "connected");
                 attempt = 0;
                 backoff = initial_backoff;
 
-                let outcome = run_connection(connection, config, shutdown_tx).await;
+                let session_span = info_span!("session", peer = %peer);
+                let outcome = run_connection(connection, config, shutdown_tx)
+                    .instrument(session_span)
+                    .await;
                 match outcome {
                     SessionOutcome::Shutdown => return Ok(()),
                     SessionOutcome::Disconnected(reason) => {
-                        warn!("connection lost: {}", reason);
+                        warn!(reason = %reason, "connection lost");
                     }
                 }
             }
             Some(Err(e)) => {
-                warn!("connection attempt failed: {}", e);
+                warn!(error = %e, "connect attempt failed");
             }
             None => unreachable!(),
         }
@@ -200,13 +201,14 @@ async fn run_with_reconnect(
             }
         }
 
+        let attempt_label = match max_retries {
+            Some(m) => format!("{attempt}/{m}"),
+            None => attempt.to_string(),
+        };
         info!(
-            "reconnecting in {:?} (attempt {}{})",
-            backoff,
-            attempt,
-            max_retries
-                .map(|m| format!("/{m}"))
-                .unwrap_or_else(|| "".to_string()),
+            backoff_ms = backoff.as_millis() as u64,
+            attempt = %attempt_label,
+            "reconnecting"
         );
         tokio::select! {
             _ = tokio::time::sleep(backoff) => {}
@@ -266,11 +268,11 @@ async fn happy_eyeballs_connect(
     while let Some((addr, res)) = races.next().await {
         match res {
             Ok(conn) => {
-                debug!(%addr, "happy eyeballs winner");
+                debug!(addr = %addr, "happy eyeballs winner");
                 return Ok(conn);
             }
             Err(e) => {
-                debug!(%addr, error = %e, "happy eyeballs candidate failed");
+                debug!(addr = %addr, error = %e, "happy eyeballs candidate failed");
                 last_error = Some(format!("{addr}: {e}"));
             }
         }
@@ -298,11 +300,7 @@ async fn proxied_connect(
         .first()
         .copied()
         .ok_or_else(|| anyhow!("no candidate addresses to connect to"))?;
-    debug!(
-        target = %server,
-        proxy = %proxy,
-        "establishing SOCKS5 UDP ASSOCIATE for QUIC connection",
-    );
+    debug!(server = %server, proxy = %proxy, "opening SOCKS5 UDP ASSOCIATE for QUIC");
     let endpoint =
         create_client_endpoint_via_proxy(&config.tls, config.congestion, server, proxy).await?;
     let connection = endpoint.connect(server, server_name)?.await?;
@@ -339,7 +337,15 @@ async fn run_connection(
             return SessionOutcome::Disconnected(format!("session hello failed: {e}"));
         }
     };
-    info!("session established with {} tunnel(s)", tunnel_ids.len());
+    info!(count = tunnel_ids.len(), "session established");
+    for (remote, tunnel_id) in config.remotes.iter().zip(tunnel_ids.iter().copied()) {
+        let dir = if matches!(remote.direction, Direction::Reverse) {
+            "reverse"
+        } else {
+            "forward"
+        };
+        info!(tunnel_id, dir, spec = %remote, "tunnel registered");
+    }
 
     // Map tunnel_id → declared remote so the reverse-accept loop can
     // resolve OpenConn frames the server pushes back.
@@ -362,7 +368,7 @@ async fn run_connection(
         }
         let remote = remote.clone();
         let connection_clone = connection.clone();
-        let span = info_span!("tunnel", tunnel_id = tunnel_id, remote = %remote);
+        let span = info_span!("tunnel", tunnel_id, dir = "forward", spec = %remote);
         // Stdio tunnels are single-shot: when stdin EOFs (or the
         // remote end closes), the user expects the whole client to
         // exit cleanly — not silently keep running with no input. We
@@ -373,7 +379,7 @@ async fn run_connection(
         let task = task::spawn(
             async move {
                 if let Err(e) = handle_forward_tunnel(connection_clone, remote, tunnel_id).await {
-                    error!("failed: {}", e)
+                    error!(error = %e, "forward tunnel failed");
                 }
                 if let Some(tx) = shutdown_for_task {
                     let _ = tx.send(());
@@ -392,7 +398,7 @@ async fn run_connection(
             let quic_connection = connection_clone.clone();
             let remotes = remotes_for_accept.clone();
             if let Err(e) = client_accept_reverse_conn(quic_connection, remotes).await {
-                debug!("reverse conn accept loop ended: {}", e);
+                debug!(error = %e, "reverse-accept loop ended");
                 break;
             }
         }
@@ -403,7 +409,7 @@ async fn run_connection(
     let mut shutdown_rx = shutdown_tx.subscribe();
     let outcome = tokio::select! {
         _ = shutdown_rx.recv() => {
-            info!("Shutting down client and notifying server...");
+            info!("disconnecting and notifying server");
             // Close the QUIC connection with a non-zero application code and
             // a human-readable reason. The server logs this verbatim, so the
             // operator on the other end sees "client closed (code 130, client
@@ -490,7 +496,7 @@ async fn client_accept_reverse_conn(
         let open = match receive_open_conn(&mut recv).await {
             Ok(o) => o,
             Err(e) => {
-                error!("failed to read OpenConn frame: {e}");
+                error!(error = %e, "failed to read OpenConn frame");
                 return;
             }
         };
@@ -504,8 +510,8 @@ async fn client_accept_reverse_conn(
                 )
                 .await;
                 error!(
-                    "server pushed conn for unknown tunnel id {}",
-                    open.tunnel_id
+                    tunnel_id = open.tunnel_id,
+                    "server pushed conn for unknown tunnel"
                 );
                 return;
             }
@@ -519,25 +525,29 @@ async fn client_accept_reverse_conn(
             Ok(d) => d,
             Err(e) => {
                 let _ = reply_open_conn(&mut send, &OpenConnResponse::Failed(e.to_string())).await;
-                error!("reverse OpenConn dispatch error: {e}");
+                error!(error = %e, "reverse OpenConn dispatch error");
                 return;
             }
         };
 
         if let Err(e) = reply_open_conn(&mut send, &OpenConnResponse::Ok).await {
-            error!("failed to ack reverse OpenConn: {e}");
+            error!(error = %e, "failed to ack reverse OpenConn");
             return;
         }
 
-        let span = info_span!("conn", tunnel_id = open.tunnel_id, remote = %dispatch);
+        let span =
+            info_span!("conn", tunnel_id = open.tunnel_id, dir = "reverse", target = %dispatch);
         async move {
-            info!("reverse conn opened");
+            info!("conn opened");
+            let started = std::time::Instant::now();
             let result = match dispatch {
                 ReverseDispatch::Tcp(req) => tunnel_tcp_server(recv, send, req, None).await,
                 ReverseDispatch::Udp(req) => tunnel_udp_server(recv, send, req, None).await,
             };
-            if let Err(e) = result {
-                debug!("reverse conn ended: {e}");
+            let dur_ms = started.elapsed().as_millis() as u64;
+            match &result {
+                Ok(()) => info!(dur_ms, "conn closed"),
+                Err(e) => debug!(dur_ms, error = %e, "conn closed (error)"),
             }
         }
         .instrument(span)

--- a/src/common/proxy.rs
+++ b/src/common/proxy.rs
@@ -231,8 +231,8 @@ async fn establish_socks5_udp_associate(
             let mut name = vec![0u8; len_buf[0] as usize];
             tcp.read_exact(&mut name).await?;
             warn!(
-                "SOCKS5 proxy returned domain BND.ADDR `{}`; using proxy peer IP instead",
-                String::from_utf8_lossy(&name)
+                bnd_addr = %String::from_utf8_lossy(&name),
+                "SOCKS5 proxy returned domain BND.ADDR; falling back to proxy peer IP",
             );
             tcp.peer_addr()?.ip()
         }
@@ -494,22 +494,16 @@ impl AsyncUdpSocket for Socks5UdpSocket {
                         // A datagram from somewhere other than the proxy's
                         // relay endpoint — skip it. Most likely a stray
                         // packet from a previous association, or a probe.
-                        debug!(
-                            "ignoring unexpected datagram from {} on SOCKS5-proxied socket",
-                            src
-                        );
+                        debug!(from = %src, "ignoring unexpected datagram on socks5-proxied socket");
                         continue;
                     }
                     let used = &mut buf[..n];
                     let Some((inner_src, payload_len)) = unwrap_socks5_udp_in_place(used) else {
-                        debug!("dropping malformed SOCKS5 UDP datagram (len={n})");
+                        debug!(len = n, "dropping malformed socks5 udp datagram");
                         continue;
                     };
                     if inner_src != self.target {
-                        debug!(
-                            "ignoring SOCKS5 datagram with inner src {} (expected {})",
-                            inner_src, self.target
-                        );
+                        debug!(inner_src = %inner_src, expected = %self.target, "ignoring socks5 datagram with mismatched inner src");
                         continue;
                     }
                     meta[0] = quinn::udp::RecvMeta {
@@ -572,12 +566,12 @@ impl TcpKeepalive {
             loop {
                 match read.read(&mut sink).await {
                     Ok(0) => {
-                        debug!("SOCKS5 proxy closed the control TCP connection");
+                        debug!("socks5 proxy closed control tcp");
                         break;
                     }
-                    Ok(n) => debug!("SOCKS5 proxy sent {n} unexpected bytes on control channel"),
+                    Ok(n) => debug!(bytes = n, "socks5 proxy sent unexpected bytes on control"),
                     Err(e) => {
-                        debug!("SOCKS5 control TCP read error: {e}");
+                        debug!(error = %e, "socks5 control tcp read error");
                         break;
                     }
                 }

--- a/src/common/quic.rs
+++ b/src/common/quic.rs
@@ -166,7 +166,7 @@ fn load_server_identity(
 
     if let Some(leaf) = cert_chain.first() {
         let fp = format_fingerprint(&cert_sha256(leaf));
-        info!("server cert fingerprint: {fp}");
+        info!(fingerprint = %fp, "server cert");
     }
 
     Ok((cert_chain, key))
@@ -182,17 +182,11 @@ fn load_or_create_self_signed(
     let key_path = state_dir.join("server.key");
 
     if cert_path.exists() && key_path.exists() {
-        debug!(
-            "loading persisted self-signed identity from {}",
-            state_dir.display()
-        );
+        debug!(dir = %state_dir.display(), "loading persisted self-signed identity");
         return load_pem_identity(&cert_path, &key_path);
     }
 
-    info!(
-        "no persisted server identity found in {}; generating a new self-signed cert",
-        state_dir.display()
-    );
+    info!(dir = %state_dir.display(), "generating new self-signed identity");
     fs::create_dir_all(state_dir)
         .with_context(|| format!("failed to create state dir {}", state_dir.display()))?;
 
@@ -206,9 +200,9 @@ fn load_or_create_self_signed(
     write_secret_file(&key_path, key_pem.as_bytes())
         .with_context(|| format!("failed to write {}", key_path.display()))?;
     info!(
-        "persisted server identity to {} and {}",
-        cert_path.display(),
-        key_path.display()
+        cert = %cert_path.display(),
+        key = %key_path.display(),
+        "persisted server identity",
     );
 
     let cert_der: CertificateDer<'static> = generated.cert.into();
@@ -262,7 +256,7 @@ fn load_root_store(ca_path: &Path) -> Result<rustls::RootCertStore> {
         })?;
         added += 1;
     }
-    debug!("loaded {added} CA cert(s) from {}", ca_path.display());
+    debug!(count = added, path = %ca_path.display(), "loaded CA certs");
     Ok(roots)
 }
 
@@ -292,10 +286,7 @@ fn build_quic_server_config(
             .with_no_client_auth()
             .with_single_cert(cert, key)?,
         ServerTlsConfig::Mtls { ca, .. } => {
-            info!(
-                "mTLS enabled: requiring client certificates signed by {}",
-                ca.display()
-            );
+            info!(ca = %ca.display(), "mTLS enabled (requiring client cert)");
             let roots = load_root_store(ca)?;
             let verifier = rustls::server::WebPkiClientVerifier::builder(Arc::new(roots))
                 .build()
@@ -338,10 +329,7 @@ fn build_quic_client_config(tls: &ClientTlsConfig) -> Result<ClientConfig> {
             let roots = load_root_store(ca)?;
             let (cert_chain, key) = load_pem_identity(cert, key)?;
             if let Some(leaf) = cert_chain.first() {
-                debug!(
-                    "client cert fingerprint: {}",
-                    format_fingerprint(&cert_sha256(leaf))
-                );
+                debug!(fingerprint = %format_fingerprint(&cert_sha256(leaf)), "client cert");
             }
             TlsClientConfig::builder()
                 .with_root_certificates(roots)
@@ -486,9 +474,9 @@ impl rustls::client::danger::ServerCertVerifier for FingerprintVerifier {
             Ok(rustls::client::danger::ServerCertVerified::assertion())
         } else {
             warn!(
-                "server cert fingerprint mismatch: expected {}, got {}",
-                format_fingerprint(&self.expected),
-                format_fingerprint(&actual),
+                expected = %format_fingerprint(&self.expected),
+                actual = %format_fingerprint(&actual),
+                "server cert fingerprint mismatch",
             );
             Err(rustls::Error::InvalidCertificate(
                 rustls::CertificateError::ApplicationVerificationFailure,

--- a/src/common/socks.rs
+++ b/src/common/socks.rs
@@ -9,7 +9,7 @@ use quinn::{Connection, RecvStream, SendStream};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream, UdpSocket};
 use tokio::sync::mpsc;
-use tracing::{debug, debug_span, error, info, warn, Instrument};
+use tracing::{debug, error, info, info_span, warn, Instrument};
 
 use super::remote::{DynamicTarget, HostPort, OpenConn, RemoteRequest};
 use super::tcp::{tunnel_tcp_stream, Counters, TunnelHandleOpt};
@@ -39,87 +39,109 @@ pub async fn tunnel_socks_client(
 ) -> Result<()> {
     let local_addr = remote.local_socket_addr();
     let listener = TcpListener::bind(local_addr).await?;
-    info!("SOCKS5 listening on {}", local_addr);
+    info!(addr = %local_addr, proto = "socks5", "listening");
 
-    let conn_counter = AtomicUsize::new(0);
+    let local_counter = AtomicUsize::new(0);
 
     loop {
-        let (mut local_conn, peer_addr) = listener.accept().await?;
+        let (mut local_conn, peer) = listener.accept().await?;
         let connection = quic_connection.clone();
         let remote = remote.clone();
         let tunnel_handle = handle.clone();
-        let conn_id = conn_counter.fetch_add(1, Ordering::Relaxed) + 1;
-        let span = debug_span!("conn", id = conn_id, peer = %peer_addr);
+        let local_id = (local_counter.fetch_add(1, Ordering::Relaxed) + 1) as u64;
 
         // Fire-and-forget: each accepted SOCKS5 connection runs to completion
         // in its own task so the accept loop never blocks on a slow handshake
         // (regression of #20 §1).
-        tokio::spawn(
-            async move {
-                let request = match socks_handshake(&mut local_conn).await {
-                    Ok(r) => r,
-                    Err(e) => {
-                        error!("handshake error: {}", e);
-                        return;
-                    }
-                };
+        tokio::spawn(async move {
+            let request = match socks_handshake(&mut local_conn).await {
+                Ok(r) => r,
+                Err(e) => {
+                    let span = info_span!("socks5", peer = %peer);
+                    let _g = span.enter();
+                    warn!(error = %e, "handshake failed");
+                    return;
+                }
+            };
 
-                match request {
-                    SocksRequest::Connect(target) => {
-                        debug!(target = %target, "SOCKS5 CONNECT");
-
-                        let (send, recv) = match connection.open_bi().await {
-                            Ok(stream) => stream,
-                            Err(e) => {
-                                error!("failed to open stream: {}", e);
-                                return;
-                            }
-                        };
-
-                        // One admin conn per SOCKS CONNECT, labelled
-                        // with the SOCKS client's source plus the target
-                        // it asked for so operators can spot which CONNECT
-                        // is blocking on what.
-                        let _conn_guard = tunnel_handle
-                            .as_ref()
-                            .map(|h| h.open_conn(Some(format!("{peer_addr}=>{target}"))));
-                        if let Some(g) = _conn_guard.as_ref() {
-                            info!(
-                                conn_id = g.id(),
-                                peer = %peer_addr,
-                                target = %target,
-                                "conn opened"
-                            );
+            match request {
+                SocksRequest::Connect(target) => {
+                    let (send, recv) = match connection.open_bi().await {
+                        Ok(stream) => stream,
+                        Err(e) => {
+                            let span = info_span!("socks5", peer = %peer);
+                            let _g = span.enter();
+                            error!(error = %e, "failed to open quic stream");
+                            return;
                         }
-                        let counters = _conn_guard.as_ref().map(|g| g.counters());
+                    };
 
-                        if let Err(e) = start_client_dynamic_tunnel(
-                            local_conn, send, recv, tunnel_id, target, counters,
+                    // One admin conn per SOCKS CONNECT, labelled
+                    // with the SOCKS client's source plus the target
+                    // it asked for so operators can spot which CONNECT
+                    // is blocking on what.
+                    let conn_guard = tunnel_handle
+                        .as_ref()
+                        .map(|h| h.open_conn(Some(format!("{peer}=>{target}"))));
+                    let conn_id = conn_guard.as_ref().map(|g| g.id()).unwrap_or(local_id);
+                    let counters = conn_guard.as_ref().map(|g| g.counters());
+
+                    let span = info_span!(
+                        "conn",
+                        conn_id,
+                        tunnel_id,
+                        peer = %peer,
+                        target = %target,
+                        proto = "socks5/tcp",
+                    );
+                    async move {
+                        info!("conn opened");
+                        let started = std::time::Instant::now();
+                        let result = start_client_dynamic_tunnel(
+                            local_conn,
+                            send,
+                            recv,
+                            tunnel_id,
+                            target,
+                            counters.clone(),
                         )
-                        .await
-                        {
-                            error!("dynamic tunnel error: {}", e);
+                        .await;
+                        let dur_ms = started.elapsed().as_millis() as u64;
+                        let snap = counters.as_ref().map(|c| c.snapshot());
+                        match (&result, snap) {
+                            (Ok(()), Some((bytes_in, bytes_out))) => {
+                                info!(bytes_in, bytes_out, dur_ms, "conn closed")
+                            }
+                            (Ok(()), None) => info!(dur_ms, "conn closed"),
+                            (Err(e), _) => warn!(dur_ms, error = %e, "conn closed (error)"),
                         }
+                        drop(conn_guard);
                     }
-                    SocksRequest::UdpAssociate => {
-                        debug!("SOCKS5 UDP ASSOCIATE");
+                    .instrument(span)
+                    .await;
+                }
+                SocksRequest::UdpAssociate => {
+                    let span = info_span!("socks5-udp", peer = %peer);
+                    async move {
+                        debug!("UDP ASSOCIATE requested");
                         if let Err(e) = handle_socks_udp_associate(
                             connection,
                             local_conn,
                             &remote,
                             tunnel_handle,
-                            peer_addr,
+                            peer,
                             tunnel_id,
                         )
                         .await
                         {
-                            error!("UDP ASSOCIATE error: {}", e);
+                            error!(error = %e, "UDP ASSOCIATE failed");
                         }
                     }
+                    .instrument(span)
+                    .await;
                 }
             }
-            .instrument(span),
-        );
+        });
     }
 }
 
@@ -266,7 +288,7 @@ async fn handle_socks_udp_associate(
     let bind_addr = SocketAddr::new(listen_ip, 0);
     let udp_socket = Arc::new(UdpSocket::bind(bind_addr).await?);
     let bound = udp_socket.local_addr()?;
-    debug!(udp = %bound, "SOCKS5 UDP relay bound");
+    debug!(addr = %bound, "UDP ASSOCIATE relay bound");
 
     write_socks_udp_associate_reply(&mut tcp_conn, bound).await?;
 
@@ -279,7 +301,7 @@ async fn handle_socks_udp_associate(
             if let Err(e) =
                 run_socks_udp_relay(connection, tunnel_id, socket, handle, socks_peer).await
             {
-                debug!("UDP ASSOCIATE relay ended: {}", e);
+                debug!(error = %e, "UDP relay ended");
             }
         }
     });
@@ -294,7 +316,7 @@ async fn handle_socks_udp_associate(
         }
     }
     relay_handle.abort();
-    debug!("SOCKS5 UDP ASSOCIATE control connection closed");
+    debug!("UDP ASSOCIATE control closed");
     Ok(())
 }
 
@@ -341,7 +363,7 @@ async fn run_socks_udp_relay(
         let (target, payload) = match parse_socks_udp_header(&buf[..n]) {
             Ok(v) => v,
             Err(e) => {
-                debug!(peer = %src, "invalid SOCKS5 UDP datagram: {}", e);
+                debug!(peer = %src, error = %e, "invalid UDP datagram");
                 continue;
             }
         };
@@ -377,7 +399,7 @@ async fn run_socks_udp_relay(
         // UDP is unreliable: drop on backpressure or after the conn
         // terminated rather than blocking the receive loop.
         if let Err(e) = tx.try_send(Bytes::copy_from_slice(payload)) {
-            debug!(peer = %src, target = %target, "dropping UDP datagram: {}", e);
+            debug!(peer = %src, target = %target, error = %e, "dropping udp datagram");
         }
     }
 }
@@ -396,37 +418,49 @@ fn spawn_socks_udp_conn(
 ) {
     let key = (source, target.clone());
     tokio::spawn(async move {
-        debug!(peer = %source, target = %target, "opening SOCKS5 UDP conn");
         // One admin conn per (SOCKS-source, UDP-target) pair so the
         // operator can spot a single greedy target over a shared
         // SOCKS UDP association.
-        let _conn_guard = handle
+        let conn_guard = handle
             .as_ref()
             .map(|h| h.open_conn(Some(format!("{socks_peer}=>{target}"))));
-        if let Some(g) = _conn_guard.as_ref() {
-            info!(
-                conn_id = g.id(),
-                peer = %socks_peer,
-                target = %target,
-                "conn opened"
-            );
-        }
-        let counters = _conn_guard.as_ref().map(|g| g.counters());
-        if let Err(e) = run_socks_udp_conn(
-            quic_connection,
+        let conn_id = conn_guard.as_ref().map(|g| g.id()).unwrap_or(0);
+        let counters = conn_guard.as_ref().map(|g| g.counters());
+        let span = info_span!(
+            "conn",
+            conn_id,
             tunnel_id,
-            udp_socket,
-            source,
-            target,
-            rx,
-            counters,
-        )
-        .await
-        {
-            warn!(peer = %source, "SOCKS5 UDP conn ended: {}", e);
+            peer = %socks_peer,
+            target = %target,
+            proto = "socks5/udp",
+        );
+        async move {
+            info!("conn opened");
+            let started = std::time::Instant::now();
+            let result = run_socks_udp_conn(
+                quic_connection,
+                tunnel_id,
+                udp_socket,
+                source,
+                target,
+                rx,
+                counters.clone(),
+            )
+            .await;
+            let dur_ms = started.elapsed().as_millis() as u64;
+            let snap = counters.as_ref().map(|c| c.snapshot());
+            match (&result, snap) {
+                (Ok(()), Some((bytes_in, bytes_out))) => {
+                    info!(bytes_in, bytes_out, dur_ms, "conn closed")
+                }
+                (Ok(()), None) => info!(dur_ms, "conn closed"),
+                (Err(e), _) => warn!(dur_ms, error = %e, "conn closed (error)"),
+            }
         }
+        .instrument(span)
+        .await;
+        drop(conn_guard);
         conns.remove(&key);
-        debug!(peer = %key.0, target = %key.1, "SOCKS5 UDP conn removed");
     });
 }
 
@@ -470,7 +504,7 @@ async fn run_socks_udp_conn(
                 }
                 Ok(None) => return Ok::<(), anyhow::Error>(()),
                 Err(_) => {
-                    debug!(peer = %source, target = %target, "SOCKS5 UDP conn idle timeout");
+                    debug!("idle timeout");
                     return Ok(());
                 }
             }

--- a/src/common/tcp.rs
+++ b/src/common/tcp.rs
@@ -8,7 +8,7 @@ use tokio::{
     net::{TcpListener, TcpStream},
     sync::Notify,
 };
-use tracing::{debug, debug_span, info, Instrument};
+use tracing::{debug, info, info_span, Instrument};
 
 use crate::common::counted::{CountedReader, TunnelCounters};
 use crate::common::remote::OpenConn;
@@ -73,7 +73,7 @@ pub async fn tunnel_tcp_stream(
     // tunneled TCP — forward, reverse, and SOCKS — flows through here, so
     // this single call covers every path.
     if let Err(e) = tcp_stream.set_nodelay(true) {
-        debug!("set_nodelay failed: {}", e);
+        debug!(error = %e, "set_nodelay failed");
     }
 
     let (tcp_recv, mut tcp_send) = tcp_stream.into_split();
@@ -198,9 +198,9 @@ pub async fn tunnel_tcp_stream(
     // it as a leak.
     let (c2s, s2c) = tokio::join!(client_to_server, server_to_client);
     match (&c2s, &s2c) {
-        (Ok(_), Ok(_)) => debug!("closed"),
-        (Err(e), _) => debug!("client→server error: {}", e),
-        (_, Err(e)) => debug!("server→client error: {}", e),
+        (Ok(_), Ok(_)) => debug!("stream closed"),
+        (Err(e), _) => debug!(direction = "tx", error = %e, "stream copy error"),
+        (_, Err(e)) => debug!(direction = "rx", error = %e, "stream copy error"),
     }
     Ok(())
 }
@@ -239,7 +239,7 @@ pub async fn tunnel_stdio_client(quic_connection: Connection, tunnel_id: u64) ->
         &mut recv,
     )
     .await?;
-    info!("stdio tunnel ready (piping stdin/stdout)");
+    info!("stdio tunnel ready");
 
     let mut stdin = BufReader::with_capacity(TUNNEL_COPY_BUF, tokio::io::stdin());
     let mut stdout = tokio::io::stdout();
@@ -305,8 +305,8 @@ pub async fn tunnel_stdio_client(quic_connection: Connection, tunnel_id: u64) ->
     let (s2q, q2s) = tokio::join!(stdin_to_quic, quic_to_stdout);
     match (&s2q, &q2s) {
         (Ok(_), Ok(_)) => debug!("stdio tunnel closed"),
-        (Err(e), _) => debug!("stdin→quic error: {}", e),
-        (_, Err(e)) => debug!("quic→stdout error: {}", e),
+        (Err(e), _) => debug!(direction = "tx", error = %e, "stdio copy error"),
+        (_, Err(e)) => debug!(direction = "rx", error = %e, "stdio copy error"),
     }
     Ok(())
 }
@@ -322,51 +322,80 @@ pub async fn tunnel_tcp_client(
     // `IpAddr` produces `::1:8080`, which `TcpListener::bind` rejects.
     let local_addr = remote.local_socket_addr();
     let listener = TcpListener::bind(local_addr).await?;
-    info!("listening on {}", local_addr);
+    info!(addr = %local_addr, "listening");
 
-    let conn_counter = AtomicUsize::new(0);
+    // Local fallback counter for log-only correlation when admin
+    // tracking is disabled (handle is None, i.e. forward client side).
+    let local_counter = AtomicUsize::new(0);
 
     loop {
-        let (local_socket, addr) = listener.accept().await?;
-        let conn_id = conn_counter.fetch_add(1, Ordering::Relaxed) + 1;
-        let span = debug_span!("conn", id = conn_id, peer = %addr);
-
+        let (local_socket, peer) = listener.accept().await?;
         let connection = quic_connection.clone();
         let handle = handle.clone();
-        tokio::spawn(
-            async move {
-                debug!("open");
-                let (mut send, mut recv) = connection.open_bi().await?;
+        let local_id = (local_counter.fetch_add(1, Ordering::Relaxed) + 1) as u64;
 
-                // Tell the peer which tunnel this stream belongs to.
-                // Static TCP tunnels carry no `dynamic` payload — the
-                // peer already knows the target from the tunnel's
-                // declaration in the session hello.
-                send_open_conn(
-                    &OpenConn {
-                        tunnel_id,
-                        dynamic: None,
-                    },
-                    &mut send,
-                    &mut recv,
-                )
-                .await?;
-
-                // Register this accepted connection as a conn against
-                // the parent tunnel (when admin tracking is enabled).
-                // The `ConnGuard` removes it again on drop, regardless
-                // of how the stream below ends.
-                let _conn_guard = handle.as_ref().map(|h| h.open_conn(Some(addr.to_string())));
-                if let Some(g) = _conn_guard.as_ref() {
-                    info!(conn_id = g.id(), peer = %addr, "conn opened");
+        tokio::spawn(async move {
+            let (mut send, mut recv) = match connection.open_bi().await {
+                Ok(s) => s,
+                Err(e) => {
+                    let span = info_span!("conn", conn_id = local_id, tunnel_id, peer = %peer);
+                    let _g = span.enter();
+                    debug!(error = %e, "open_bi failed");
+                    return Err::<(), anyhow::Error>(e.into());
                 }
-                let counters = _conn_guard.as_ref().map(|g| g.counters());
+            };
 
-                tunnel_tcp_stream(local_socket, send, recv, counters).await?;
-                Ok::<(), anyhow::Error>(())
+            // Tell the peer which tunnel this stream belongs to.
+            // Static TCP tunnels carry no `dynamic` payload — the
+            // peer already knows the target from the tunnel's
+            // declaration in the session hello.
+            if let Err(e) = send_open_conn(
+                &OpenConn {
+                    tunnel_id,
+                    dynamic: None,
+                },
+                &mut send,
+                &mut recv,
+            )
+            .await
+            {
+                let span = info_span!("conn", conn_id = local_id, tunnel_id, peer = %peer);
+                let _g = span.enter();
+                debug!(error = %e, "OpenConn rejected");
+                return Err(e);
             }
-            .instrument(span),
-        );
+
+            // Register this accepted connection as a conn against
+            // the parent tunnel (when admin tracking is enabled).
+            // The `ConnGuard` removes it again on drop, regardless
+            // of how the stream below ends.
+            let conn_guard = handle.as_ref().map(|h| h.open_conn(Some(peer.to_string())));
+            let conn_id = conn_guard.as_ref().map(|g| g.id()).unwrap_or(local_id);
+            let counters = conn_guard.as_ref().map(|g| g.counters());
+
+            let span = info_span!("conn", conn_id, tunnel_id, peer = %peer);
+            async move {
+                info!("conn opened");
+                let started = std::time::Instant::now();
+                let result = tunnel_tcp_stream(local_socket, send, recv, counters.clone()).await;
+                let dur_ms = started.elapsed().as_millis() as u64;
+                let snap = counters.as_ref().map(|c| c.snapshot());
+                match (&result, snap) {
+                    (Ok(()), Some((bytes_in, bytes_out))) => {
+                        info!(bytes_in, bytes_out, dur_ms, "conn closed")
+                    }
+                    (Ok(()), None) => info!(dur_ms, "conn closed"),
+                    (Err(e), Some((bytes_in, bytes_out))) => {
+                        debug!(bytes_in, bytes_out, dur_ms, error = %e, "conn closed (error)")
+                    }
+                    (Err(e), None) => debug!(dur_ms, error = %e, "conn closed (error)"),
+                }
+                drop(conn_guard);
+                result
+            }
+            .instrument(span)
+            .await
+        });
     }
 }
 
@@ -379,9 +408,9 @@ pub async fn tunnel_tcp_server(
     let remote_addr = request
         .remote_addr_string()
         .ok_or_else(|| anyhow::anyhow!("TCP server tunnel requires a host:port remote"))?;
-    debug!("connecting to {}", remote_addr);
+    debug!(target = %remote_addr, "dialing");
     let tcp_stream = TcpStream::connect(&remote_addr).await?;
-    debug!("connected to {}", remote_addr);
+    debug!(target = %remote_addr, "dialed");
 
     tunnel_tcp_stream(tcp_stream, send_channel, recv_channel, counters).await?;
 

--- a/src/common/tunnel.rs
+++ b/src/common/tunnel.rs
@@ -85,10 +85,7 @@ pub async fn client_send_session_hello(
                     hello.remotes.len()
                 ));
             }
-            debug!(
-                "session accepted, {} tunnel(s) registered",
-                tunnel_ids.len()
-            );
+            debug!(count = tunnel_ids.len(), "session hello accepted");
             Ok(tunnel_ids)
         }
         SessionHelloResponse::Failed(reason) => Err(anyhow!("server rejected session: {reason}")),

--- a/src/common/udp.rs
+++ b/src/common/udp.rs
@@ -8,7 +8,7 @@ use quinn::{Connection, RecvStream, SendStream};
 use std::net::SocketAddr;
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, info_span, warn, Instrument};
 
 use crate::common::remote::OpenConn;
 use crate::common::tcp::{Counters, TunnelHandleOpt};
@@ -94,10 +94,10 @@ pub async fn tunnel_udp_stream(
         pump_stream_to_socket(udp_socket, udp_address, recv_channel, counters),
     );
     if let Err(e) = l2q {
-        debug!("local→quic error: {}", e);
+        debug!(direction = "tx", error = %e, "udp pump error");
     }
     if let Err(e) = q2l {
-        debug!("quic→local error: {}", e);
+        debug!(direction = "rx", error = %e, "udp pump error");
     }
     Ok(())
 }
@@ -116,7 +116,7 @@ async fn pump_socket_to_stream(
     loop {
         let (len, received_addr) = udp_socket.recv_from(&mut buf).await?;
         if received_addr != udp_address {
-            debug!(peer = %received_addr, expected = %udp_address, "dropping datagram from unexpected source");
+            debug!(from = %received_addr, expected = %udp_address, "dropping unexpected udp source");
             continue;
         }
         write_datagram(&mut send, &buf[..len]).await?;
@@ -157,7 +157,7 @@ pub async fn tunnel_udp_client(
     let listen_addr = remote.local_socket_addr();
     let udp_socket = Arc::new(UdpSocket::bind(listen_addr).await?);
 
-    info!("listening on {}", listen_addr);
+    info!(addr = %listen_addr, proto = "udp", "listening");
 
     // DashMap (sharded RwLock) replaces a single global Mutex<HashMap> so the
     // per-source lookup on every received datagram doesn't serialize the
@@ -211,7 +211,7 @@ pub async fn tunnel_udp_client(
         // UDP is unreliable — if the conn is backpressured or has already
         // terminated, dropping the packet is correct.
         if let Err(e) = sender.try_send(payload) {
-            debug!(peer = %src, "dropping UDP datagram: {}", e);
+            debug!(peer = %src, error = %e, "dropping udp datagram");
         }
     }
 }
@@ -227,23 +227,43 @@ fn spawn_udp_conn(
     tunnel_id: u64,
 ) {
     tokio::spawn(async move {
-        debug!(peer = %source, "opening UDP conn");
         // Per-source UDP aggregator → one admin-side conn, scoped to
         // the lifetime of the spawn.
-        let _conn_guard = handle
+        let conn_guard = handle
             .as_ref()
             .map(|h| h.open_conn(Some(source.to_string())));
-        if let Some(g) = _conn_guard.as_ref() {
-            info!(conn_id = g.id(), peer = %source, "conn opened");
+        let conn_id = conn_guard.as_ref().map(|g| g.id()).unwrap_or(0);
+        let counters = conn_guard.as_ref().map(|g| g.counters());
+        let span = info_span!("conn", conn_id, tunnel_id, peer = %source, proto = "udp");
+        async move {
+            info!("conn opened");
+            let started = std::time::Instant::now();
+            let result = run_udp_conn(
+                quic_connection,
+                tunnel_id,
+                udp_socket,
+                source,
+                rx,
+                counters.clone(),
+            )
+            .await;
+            let dur_ms = started.elapsed().as_millis() as u64;
+            let snap = counters.as_ref().map(|c| c.snapshot());
+            match (&result, snap) {
+                (Ok(()), Some((bytes_in, bytes_out))) => {
+                    info!(bytes_in, bytes_out, dur_ms, "conn closed")
+                }
+                (Ok(()), None) => info!(dur_ms, "conn closed"),
+                (Err(e), Some((bytes_in, bytes_out))) => {
+                    warn!(bytes_in, bytes_out, dur_ms, error = %e, "conn closed (error)")
+                }
+                (Err(e), None) => warn!(dur_ms, error = %e, "conn closed (error)"),
+            }
         }
-        let counters = _conn_guard.as_ref().map(|g| g.counters());
-        if let Err(e) =
-            run_udp_conn(quic_connection, tunnel_id, udp_socket, source, rx, counters).await
-        {
-            warn!(peer = %source, "UDP conn ended: {}", e);
-        }
+        .instrument(span)
+        .await;
+        drop(conn_guard);
         conns.remove(&source);
-        debug!(peer = %source, "UDP conn removed");
     });
 }
 
@@ -279,7 +299,7 @@ async fn run_udp_conn(
                 }
                 Ok(None) => return Ok::<(), anyhow::Error>(()), // sender side closed
                 Err(_) => {
-                    debug!(peer = %source, "UDP conn idle timeout");
+                    debug!("idle timeout");
                     return Ok(());
                 }
             }
@@ -329,7 +349,7 @@ pub async fn tunnel_udp_server(
     };
     let udp_socket = Arc::new(UdpSocket::bind(bind_addr).await?);
 
-    debug!("connecting to {}", remote_addr);
+    debug!(target = %remote_addr, "udp dial");
 
     tunnel_udp_stream(
         udp_socket,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::time::Duration;
-use tracing::{error, info};
+use tracing::{debug, error};
 
 pub mod cert;
 pub mod client;
@@ -160,10 +160,10 @@ impl Default for ReconnectConfig {
 /// directly so they don't end up nesting runtimes (which would either panic
 /// in debug builds or silently deadlock in release).
 pub fn run_server(config: ServerConfig) {
-    info!("running server");
+    debug!("starting server runtime");
     let result = build_runtime().and_then(|rt| rt.block_on(server::run_async(config)));
     if let Err(e) = result {
-        error!("an error occurred: {}", e);
+        error!(error = %e, "server exited with error");
     }
 }
 
@@ -172,10 +172,10 @@ pub fn run_server(config: ServerConfig) {
 /// See [`run_server`] for the rationale on why embedders should prefer
 /// [`client::run_async`].
 pub fn run_client(config: ClientConfig) {
-    info!("running client");
+    debug!("starting client runtime");
     let result = build_runtime().and_then(|rt| rt.block_on(client::run_async(config)));
     if let Err(e) = result {
-        error!("an error occurred: {}", e);
+        error!(error = %e, "client exited with error");
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,16 @@ use std::str::FromStr;
 use std::time::Duration;
 use tracing::{debug, info};
 
+/// Output format for the log subscriber. `compact` is the default —
+/// human-friendly, ANSI-coloured when stderr is a TTY. `json` emits one
+/// JSON object per event for ingestion by log aggregators.
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+enum LogFormat {
+    #[default]
+    Compact,
+    Json,
+}
+
 /// Parse a non-negative integer number of seconds into a [`Duration`].
 fn parse_duration_secs(s: &str) -> Result<Duration, String> {
     let secs: u64 = s
@@ -259,13 +269,21 @@ enum Mode {
         #[arg(long, default_value_t = false)]
         no_admin_socket: bool,
 
-        /// enable verbose logging
+        /// enable verbose logging (rusnel modules at debug level)
         #[arg(short('v'), long("verbose"), default_value_t = false)]
         is_verbose: bool,
 
-        /// enable debug logging
+        /// enable debug logging (rusnel modules at trace level)
         #[arg(long("debug"), default_value_t = false)]
         is_debug: bool,
+
+        /// suppress informational logs (warn-and-above only)
+        #[arg(short('q'), long("quiet"), default_value_t = false, conflicts_with_all = ["is_verbose", "is_debug"])]
+        is_quiet: bool,
+
+        /// log output format
+        #[arg(long, value_enum, default_value_t = LogFormat::Compact, value_name = "FORMAT")]
+        log_format: LogFormat,
     },
     /// run Rusnel in client mode
     ///
@@ -398,13 +416,21 @@ sharing <remote-host>:<remote-port> from the client to the server\'s <local-host
         #[arg(long, value_name = "URL", value_parser = parse_proxy)]
         proxy: Option<ProxyConfig>,
 
-        /// enable verbose logging
+        /// enable verbose logging (rusnel modules at debug level)
         #[arg(short('v'), long("verbose"), default_value_t = false)]
         is_verbose: bool,
 
-        /// enable debug logging
+        /// enable debug logging (rusnel modules at trace level)
         #[arg(long("debug"), default_value_t = false)]
         is_debug: bool,
+
+        /// suppress informational logs (warn-and-above only)
+        #[arg(short('q'), long("quiet"), default_value_t = false, conflicts_with_all = ["is_verbose", "is_debug"])]
+        is_quiet: bool,
+
+        /// log output format
+        #[arg(long, value_enum, default_value_t = LogFormat::Compact, value_name = "FORMAT")]
+        log_format: LogFormat,
     },
     /// generate certificates for use with --tls-* flags
     Cert {
@@ -709,8 +735,15 @@ fn main() {
             no_admin_socket,
             is_verbose,
             is_debug,
+            is_quiet,
+            log_format,
         } => {
-            set_log_level(is_verbose, is_debug);
+            init_logging(LoggingOpts {
+                verbose: is_verbose,
+                debug: is_debug,
+                quiet: is_quiet,
+                format: log_format,
+            });
 
             let embedded = match embedded::materialize() {
                 Ok(m) => m,
@@ -757,7 +790,7 @@ fn main() {
                     Some(admin_socket.unwrap_or_else(rusnel::ctl::default_socket_path))
                 },
             };
-            debug!("Initialized server with config: {:?}", server_config);
+            debug!(?server_config, "server config resolved");
             run_server(server_config);
         }
         Mode::Client {
@@ -775,8 +808,15 @@ fn main() {
             proxy,
             is_verbose,
             is_debug,
+            is_quiet,
+            log_format,
         } => {
-            set_log_level(is_verbose, is_debug);
+            init_logging(LoggingOpts {
+                verbose: is_verbose,
+                debug: is_debug,
+                quiet: is_quiet,
+                format: log_format,
+            });
 
             let embedded = match embedded::materialize() {
                 Ok(m) => m,
@@ -818,7 +858,7 @@ fn main() {
                 reconnect,
                 proxy,
             };
-            debug!("Initialized client with config: {:?}", client_config);
+            debug!(?client_config, "client config resolved");
             run_client(client_config);
         }
         Mode::Ctl {
@@ -828,12 +868,7 @@ fn main() {
         } => {
             // ctl is a one-shot client; minimal logger so error messages
             // surface but we don't pollute the formatted-table output.
-            tracing_subscriber::fmt()
-                .with_max_level(tracing::Level::WARN)
-                .with_target(false)
-                .without_time()
-                .with_writer(std::io::stderr)
-                .init();
+            init_simple_logger("rusnel=warn,warn");
             let socket_path = socket.unwrap_or_else(rusnel::ctl::default_socket_path);
             if let Err(e) = run_ctl(&socket_path, json, action) {
                 eprintln!("ctl: {}", rusnel::ctl::flatten_error(e));
@@ -843,12 +878,7 @@ fn main() {
         Mode::Cert { action } => {
             // Cert generation is a one-shot tool, not a server. Use a minimal
             // INFO logger so file paths are visible without --verbose.
-            tracing_subscriber::fmt()
-                .with_max_level(tracing::Level::INFO)
-                .with_target(false)
-                .without_time()
-                .with_writer(std::io::stderr)
-                .init();
+            init_simple_logger("rusnel=info,warn");
             if let Err(e) = run_cert(action) {
                 Args::command()
                     .error(ErrorKind::Io, format!("{e:#}"))
@@ -981,22 +1011,80 @@ mod tests {
     }
 }
 
-fn set_log_level(is_verbose: bool, is_debug: bool) {
-    let log_level = if is_debug {
-        tracing::Level::TRACE
-    } else if is_verbose {
-        tracing::Level::DEBUG
-    } else {
-        tracing::Level::INFO
-    };
-    // Log to stderr, not stdout. CLI-tool convention, and a hard
-    // requirement for forward `stdio:` remotes — those pipe the
-    // process's stdout to the tunnel, so any byte we emit on stdout
-    // becomes part of the data stream and corrupts the peer's view.
+/// Minimal subscriber for one-shot subcommands (`ctl`, `cert`). No
+/// timestamps — these tools print to a TTY where the wall-clock is the user's
+/// own session, and a leading timestamp on every line is just noise.
+fn init_simple_logger(default_directive: &'static str) {
+    use tracing_subscriber::EnvFilter;
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_directive));
     tracing_subscriber::fmt()
-        .with_max_level(log_level)
+        .with_env_filter(filter)
+        .with_target(false)
+        .without_time()
         .with_writer(std::io::stderr)
         .init();
+}
 
-    debug!("log level: {}", log_level);
+struct LoggingOpts {
+    verbose: bool,
+    debug: bool,
+    quiet: bool,
+    format: LogFormat,
+}
+
+/// Install the global tracing subscriber.
+///
+/// Filter resolution: `RUST_LOG` (if set) wins, otherwise we synthesize a
+/// directive from `--verbose` / `--debug` / `--quiet`. The synthesized
+/// directives keep noisy upstream crates (quinn, rustls) at WARN by default
+/// so the operator's own logs don't get drowned out — set
+/// `RUST_LOG=rusnel=debug,quinn=info` (or any other directive) to override.
+///
+/// Output goes to stderr (CLI convention; also a hard requirement for
+/// forward `stdio:` remotes which pipe the process's stdout to the tunnel).
+/// ANSI colours are auto-detected from the stderr TTY-ness.
+fn init_logging(opts: LoggingOpts) {
+    use std::io::IsTerminal;
+    use time::macros::format_description;
+    use tracing_subscriber::fmt::time::UtcTime;
+    use tracing_subscriber::EnvFilter;
+
+    // Synthesized default — applied only when `RUST_LOG` is unset. Keeps
+    // upstream crates (quinn, rustls, h3, hyper, …) quiet by default and
+    // turns up rusnel modules according to the verbosity flags.
+    let default_directive = if opts.debug {
+        "rusnel=trace,info"
+    } else if opts.verbose {
+        "rusnel=debug,info"
+    } else if opts.quiet {
+        "rusnel=warn,warn"
+    } else {
+        "rusnel=info,warn"
+    };
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_directive));
+
+    let ansi = std::io::stderr().is_terminal();
+    // Compact ISO-8601 UTC down to milliseconds. Long enough to be unambiguous
+    // across days; short enough to keep terminal lines readable.
+    let timer = UtcTime::new(format_description!(
+        "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:3]Z"
+    ));
+
+    let builder = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .with_ansi(ansi)
+        .with_target(false)
+        .with_timer(timer);
+
+    match opts.format {
+        LogFormat::Compact => builder.compact().init(),
+        LogFormat::Json => builder
+            .json()
+            .with_current_span(true)
+            .with_span_list(false)
+            .init(),
+    }
 }

--- a/src/server/admin.rs
+++ b/src/server/admin.rs
@@ -49,12 +49,12 @@ const DEFAULT_HISTORY_LIMIT: usize = 50;
 /// full read access to live client metadata.
 pub async fn serve(state: ServerState, path: &Path) -> Result<()> {
     let listener = bind(path)?;
-    info!(socket = %path.display(), "admin API listening");
+    info!(socket = %path.display(), "admin api listening");
     let router = router(state);
     let path_owned: PathBuf = path.to_path_buf();
     let result = accept_loop(listener, router).await;
     if let Err(e) = std::fs::remove_file(&path_owned) {
-        debug!("failed to unlink admin socket on shutdown: {e}");
+        debug!(error = %e, "failed to unlink admin socket on shutdown");
     }
     result
 }
@@ -94,7 +94,7 @@ async fn accept_loop(listener: UnixListener, router: Router) -> Result<()> {
         let (stream, _addr) = match listener.accept().await {
             Ok(s) => s,
             Err(e) => {
-                warn!("admin accept error: {e}");
+                warn!(error = %e, "admin accept error");
                 continue;
             }
         };
@@ -109,7 +109,7 @@ async fn accept_loop(listener: UnixListener, router: Router) -> Result<()> {
                 .serve_connection(io, TowerToHyperService::new(svc))
                 .await
             {
-                debug!("admin connection ended: {e}");
+                debug!(error = %e, "admin connection ended");
             }
         });
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -36,7 +36,7 @@ pub async fn run_async(config: ServerConfig) -> Result<()> {
     let endpoint =
         create_server_endpoint(config.host, config.port, &config.tls, config.congestion)?;
     let listen_addr = endpoint.local_addr()?;
-    info!("Listening on {}", listen_addr);
+    info!(addr = %listen_addr, "server listening");
 
     let client_counter = AtomicUsize::new(0);
 
@@ -71,9 +71,9 @@ pub async fn run_async(config: ServerConfig) -> Result<()> {
         tokio::select! {
             ctrl_c = signal::ctrl_c() => {
                 if let Err(e) = ctrl_c {
-                    error!("failed to listen for ^C signal: {e}");
+                    error!(error = %e, "failed to listen for ^C signal");
                 }
-                info!("Shutdown signal received. Closing endpoint and notifying clients...");
+                info!("shutdown signal received, notifying clients");
                 endpoint.close(VarInt::from_u32(CLOSE_CODE_SERVER_SHUTDOWN), b"server received ^C");
                 endpoint.wait_idle().await;
                 if let Some(h) = admin_handle {
@@ -90,9 +90,9 @@ pub async fn run_async(config: ServerConfig) -> Result<()> {
             }
             maybe_conn = endpoint.accept() => {
                 let Some(conn) = maybe_conn else { break };
-                let client_id = client_counter.fetch_add(1, Ordering::Relaxed) + 1;
-                let remote_addr = conn.remote_address();
-                let span = info_span!("client", id = client_id, remote = %remote_addr);
+                let client_id = (client_counter.fetch_add(1, Ordering::Relaxed) + 1) as u64;
+                let peer = conn.remote_address();
+                let span = info_span!("client", client_id = client_id, peer = %peer);
 
                 // Try to claim a connection permit. If the cap is reached,
                 // refuse the new connection rather than queueing it — a
@@ -102,10 +102,7 @@ pub async fn run_async(config: ServerConfig) -> Result<()> {
                     match limiter.clone().try_acquire_owned() {
                         Ok(p) => Some(p),
                         Err(_) => {
-                            warn!(
-                                remote = %remote_addr,
-                                "rejecting connection: max-connections cap reached"
-                            );
+                            warn!(peer = %peer, "rejected: max-connections cap reached");
                             conn.refuse();
                             continue;
                         }
@@ -119,18 +116,18 @@ pub async fn run_async(config: ServerConfig) -> Result<()> {
                 let state_for_client = state.clone();
                 tokio::spawn(
                     async move {
-                        info!("client connected");
+                        info!("connected");
                         match handle_client_connection(
                             conn,
                             allow_reverse,
                             allow_socks,
-                            client_id as u64,
+                            client_id,
                             state_for_client,
                         )
                         .await
                         {
-                            Ok(reason) => info!("client disconnected: {reason}"),
-                            Err(e) => error!("connection failed: {e}"),
+                            Ok(reason) => info!(reason = %reason, "disconnected"),
+                            Err(e) => error!(error = %e, "session failed"),
                         }
                         // Permit released here on drop, freeing a slot.
                         drop(permit);
@@ -197,21 +194,27 @@ async fn handle_client_connection(
             // Rejected sessions still count as a disconnect so they
             // appear in /history. The QUIC connection itself is left
             // for the client to close once it sees the failure reply.
-            error!("session hello rejected: {e}");
+            error!(error = %e, "session hello rejected");
             state.deregister_client(client_id, format!("hello rejected: {e}"));
             return Err(e);
         }
     };
+
+    info!(count = registered_tunnels.len(), "session established");
 
     // Reverse handlers own long-lived local sockets — bind them as
     // soon as the hello is accepted, before any conn flows. Forward
     // tunnels are passive on the server side; their conns arrive as
     // OpenConn frames on the per-conn loop below.
     for tunnel in &registered_tunnels {
+        let dir = match tunnel.direction {
+            Direction::Forward => "forward",
+            Direction::Reverse => "reverse",
+        };
         info!(
             tunnel_id = tunnel.id,
+            dir,
             spec = %tunnel.spec,
-            direction = ?tunnel.direction,
             "tunnel registered"
         );
         if matches!(tunnel.direction, Direction::Reverse) {
@@ -267,7 +270,7 @@ async fn handle_client_connection(
                 break Ok("connection reset by peer".to_string());
             }
             Err(e) => {
-                error!("stream error: {e}");
+                error!(error = %e, "stream error");
                 break Err(e.into());
             }
             Ok(s) => s,
@@ -277,7 +280,7 @@ async fn handle_client_connection(
         let fut = handle_open_conn(stream, state_for_conn);
         tunnels.spawn(async move {
             if let Err(e) = fut.await {
-                error!("conn failed: {}", e);
+                error!(error = %e, "conn failed");
             }
         });
     };
@@ -288,7 +291,7 @@ async fn handle_client_connection(
     let aborted = tunnels.len();
     tunnels.shutdown().await;
     if aborted > 0 {
-        debug!("aborted {aborted} tunnel task(s) on disconnect");
+        debug!(aborted, "aborted in-flight tunnel tasks");
     }
 
     let reason = match &outcome {
@@ -353,8 +356,9 @@ fn spawn_reverse_handler(
 ) {
     let handle = Arc::new(TunnelHandle::new(state, tunnel.clone()));
     let span = info_span!(
-        "reverse",
+        "tunnel",
         tunnel_id = tunnel.id,
+        dir = "reverse",
         spec = %tunnel.spec,
     );
     tasks.spawn(
@@ -376,7 +380,7 @@ fn spawn_reverse_handler(
                 }
             };
             if let Err(e) = result {
-                error!("reverse handler failed: {e}");
+                error!(error = %e, "reverse handler failed");
             }
         }
         .instrument(span),
@@ -419,26 +423,41 @@ async fn handle_open_conn(
     reply_open_conn(&mut send, &OpenConnResponse::Ok).await?;
 
     let peer = dispatch.peer_label();
-    let _conn = state.register_conn(&tunnel, peer.clone());
-    info!(
-        conn_id = _conn.id(),
+    let conn = state.register_conn(&tunnel, peer.clone());
+    let conn_id = conn.id();
+    let counters = conn.counters();
+
+    let span = info_span!(
+        "conn",
+        conn_id = conn_id,
         tunnel_id = tunnel.id,
         peer = peer.as_deref().unwrap_or("-"),
-        "conn opened"
     );
-    let counters = Some(_conn.counters());
-
-    async {
-        match dispatch {
-            ForwardDispatch::Tcp(req) => tunnel_tcp_server(recv, send, req, counters).await,
-            ForwardDispatch::Udp(req) => tunnel_udp_server(recv, send, req, counters).await,
+    async move {
+        info!("conn opened");
+        let started = std::time::Instant::now();
+        let result = match dispatch {
+            ForwardDispatch::Tcp(req) => {
+                tunnel_tcp_server(recv, send, req, Some(counters.clone())).await
+            }
+            ForwardDispatch::Udp(req) => {
+                tunnel_udp_server(recv, send, req, Some(counters.clone())).await
+            }
+        };
+        let (bytes_in, bytes_out) = counters.snapshot();
+        let dur_ms = started.elapsed().as_millis() as u64;
+        match &result {
+            Ok(()) => info!(bytes_in, bytes_out, dur_ms, "conn closed"),
+            Err(e) => warn!(bytes_in, bytes_out, dur_ms, error = %e, "conn closed (error)"),
         }
+        // Drop `conn` (the ConnGuard) to deregister now that we've
+        // logged the summary; without this it would only drop after
+        // the surrounding `?`-propagation, after which the snapshot
+        // would race with the deregister path.
+        drop(conn);
+        result
     }
-    .instrument(info_span!(
-        "conn",
-        tunnel_id = tunnel.id,
-        spec = %tunnel.spec,
-    ))
+    .instrument(span)
     .await
 }
 


### PR DESCRIPTION
Replace the global-max-level subscriber with `tracing-subscriber` + `EnvFilter`, add `--quiet` and `--log-format compact|json`, and unify every log call site around a stable span schema that mirrors the `rusnel ctl` ID model (`client_id` / `tunnel_id` / `conn_id`).

Why
- The old subscriber was a single global level knob with no per-module control and no way to gate noisy upstream crates separately, so `--debug` drowned rusnel's own messages in quinn / rustls trace output.
- Field names drifted between sites (`id` vs `client_id`, local TCP counter `id` vs admin `conn_id`, `Forward` vs `"forward"`), which made greppable correlation with the admin API unreliable.
- Connection lifecycles only logged "opened"; closing was silent unless there was an error, so basic "who used the most bytes" questions required either standing up an aggregator or shelling into the admin socket.

What changes
- `init_logging` in `src/main.rs`: `EnvFilter` honoring `RUST_LOG`, synthesized defaults that keep quinn/rustls/h3/hyper at WARN while rusnel modules respect `-v` / `--debug` / `-q`. Compact format with ISO-8601 UTC millisecond timestamps, target hidden, ANSI auto-detected from stderr TTY-ness. `--log-format json` emits one event per line for log aggregators.
- Stable spans: `client{client_id,peer}` (server) / `session{peer}` (client) → `tunnel{tunnel_id,dir,spec}` → `conn{conn_id,tunnel_id, peer,proto}`. Server-side conn span now uses the real `conn_id` from `ServerState::register_conn`; client-side falls back to a local counter when admin tracking is off.
- Every conn emits structured `conn opened` / `conn closed` events; the close line carries `bytes_in`, `bytes_out` (snapshotted from the `ConnGuard` before drop), and `dur_ms`.
- Subcommand subscribers (`ctl`, `cert`) collapsed into a shared `init_simple_logger` so they pick up `RUST_LOG` overrides too.
- Cargo.toml: enabled the `env-filter`/`fmt`/`ansi`/`json`/`time` features on `tracing-subscriber` and added `time` for the timestamp format description.
- Messages rewritten throughout server/, client/, common/{tcp,udp, socks,proxy,tunnel,quic}, server/admin, lib: lowercase, terse, present-tense, key-value structured fields instead of inline format args.
- README: marked the `RUST_LOG` TODO done and added a Logging section with the schema, flags, and a real example trace.