### PR TITLE
v0.10.2: bump Dockerfile Rust toolchain to 1.85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2026-05-05
+
+### Fixed
+
+- **Bump the Dockerfile's Rust toolchain to 1.85.** The previous pin
+  (`1.83`) couldn't parse `cpufeatures 0.3.0`'s manifest, which uses
+  `edition = "2024"` and needs Cargo 1.85+. The cargo build failed
+  silently inside the BuildKit stage, surfacing only as a confusing
+  "`/usr/local/bin/rusnel`: not found" during the subsequent
+  `COPY --from=builder`. v0.10.0 and v0.10.1 had no working GHCR
+  image for this reason; v0.10.2 does.
+
 ## [0.10.1] - 2026-05-05
 
 Release-pipeline fixes shaken out by the first `v0.10.0` tag.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "rusnel"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusnel"
 description = "Rusnel is a fast TCP/UDP tunnel, transported over and encrypted using QUIC protocol. Single executable including both client and server"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/guyte149/Rusnel"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # Build multi-arch (driven by .github/workflows/release.yml):
 #     docker buildx build --platform linux/amd64,linux/arm64 -t rusnel .
 
-ARG RUST_VERSION=1.83
+ARG RUST_VERSION=1.85
 ARG DEBIAN_VERSION=bookworm
 
 FROM rust:${RUST_VERSION}-${DEBIAN_VERSION} AS builder


### PR DESCRIPTION
## Summary

The Docker job in v0.10.1's release workflow still failed despite the Dockerfile rewrite. The "/usr/local/bin/rusnel: not found" was a downstream symptom — the real error was buried higher in the build log:

\`\`\`
error: failed to parse manifest at .../cpufeatures-0.3.0/Cargo.toml
Caused by: feature \`edition2024\` is required
The package requires the Cargo feature called \`edition2024\`, but
that feature is not stabilized in this version of Cargo (1.83.0).
\`\`\`

\`cpufeatures 0.3.0\` (transitive dep) needs Rust/Cargo 1.85+. Bumped the Dockerfile pin from 1.83 → 1.85 so cargo can parse the manifest, and the multi-stage \`COPY\` finds the binary it expects.

This is the third release-pipeline fix on top of v0.10.0; merging this should produce the first working GHCR image. Versioned 0.10.2 (patch).

Made with [Cursor](https://cursor.com)