### PR TITLE
v0.11.1: bump Dockerfile Rust toolchain to 1.85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2026-05-06
+
+### Fixed
+
+- **Dockerfile Rust toolchain bumped to 1.85.** The 1.83 pin couldn't
+  parse `clap_lex 1.1.0`'s manifest (and `cpufeatures 0.3.0` etc.),
+  which use `edition = "2024"` and need Cargo 1.85+. The cargo build
+  failed silently inside the BuildKit stage, surfacing only as a
+  confusing `/usr/local/bin/rusnel: not found` during the multi-stage
+  `COPY --from=builder`. v0.10.0, v0.10.1, and v0.11.0 had no
+  working GHCR image for this reason; v0.11.1 does.
+
 ## [0.11.0] - 2026-05-06
 
 Windows support. Tunnels, TLS, and embedded credentials now compile

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "rusnel"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusnel"
 description = "Rusnel is a fast TCP/UDP tunnel, transported over and encrypted using QUIC protocol. Single executable including both client and server"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/guyte149/Rusnel"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # Build multi-arch (driven by .github/workflows/release.yml):
 #     docker buildx build --platform linux/amd64,linux/arm64 -t rusnel .
 
-ARG RUST_VERSION=1.83
+ARG RUST_VERSION=1.85
 ARG DEBIAN_VERSION=bookworm
 
 FROM rust:${RUST_VERSION}-${DEBIAN_VERSION} AS builder


### PR DESCRIPTION
## Summary

The Docker job in v0.11.0's release workflow still failed with the same misleading "binary not found" error. The real cause is buried higher in the build log:

\`\`\`
error: failed to parse manifest at .../clap_lex-1.1.0/Cargo.toml
Caused by: feature \`edition2024\` is required
The package requires the Cargo feature called \`edition2024\`, but
that feature is not stabilized in this version of Cargo (1.83.0).
\`\`\`

\`clap_lex 1.1.0\` (and \`cpufeatures 0.3.0\` and a few others in the dep tree) declare \`edition = "2024"\` and need Cargo 1.85+. The Dockerfile was still pinned to \`rust:1.83-bookworm\`, so cargo couldn't even parse the manifest — the cargo build failed silently inside the BuildKit stage, surfacing only as a downstream \`/usr/local/bin/rusnel: not found\` during the multi-stage \`COPY --from=builder\`.

Bump the pin to \`rust:1.85-bookworm\`. One-line fix.

This is a re-roll of #46, which had the same one-line fix but was based on a now-stale 0.10.2 version (master is past v0.11.0). #46 has been closed in favour of this PR.

Versioned 0.11.0 → 0.11.1 (patch — release-infra fix only).

Made with [Cursor](https://cursor.com)