### PR TITLE
v0.11.2: bump Dockerfile Rust toolchain to 1.88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2026-05-06
+
+### Fixed
+
+- **Dockerfile Rust toolchain bumped to 1.88.** v0.11.1 bumped it to
+  1.85 to fix the `edition = "2024"` parse error from `clap_lex` and
+  `cpufeatures`, but the build then immediately tripped on
+  `time 0.3.47`'s new MSRV (`rustc 1.85.1 is not supported … requires
+  rustc 1.88.0`). Bump to the version `time` actually wants.
+
 ## [0.11.1] - 2026-05-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "rusnel"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusnel"
 description = "Rusnel is a fast TCP/UDP tunnel, transported over and encrypted using QUIC protocol. Single executable including both client and server"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/guyte149/Rusnel"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # Build multi-arch (driven by .github/workflows/release.yml):
 #     docker buildx build --platform linux/amd64,linux/arm64 -t rusnel .
 
-ARG RUST_VERSION=1.85
+ARG RUST_VERSION=1.88
 ARG DEBIAN_VERSION=bookworm
 
 FROM rust:${RUST_VERSION}-${DEBIAN_VERSION} AS builder


### PR DESCRIPTION
## Summary

v0.11.1 bumped the Dockerfile pin from 1.83 to 1.85 to fix \`feature edition2024 is required\` from \`clap_lex\` / \`cpufeatures\`. The build got further but then hit \`time 0.3.47\`'s new MSRV:

\`\`\`
error: rustc 1.85.1 is not supported by the following packages:
  time@0.3.47 requires rustc 1.88.0
  time-core@0.1.8 requires rustc 1.88.0
\`\`\`

Bump to 1.88. Each \`time\` release ratchets on the strictest MSRV among (transitive) deps, so this is mostly a "follow upstream" maintenance task.

Versioned 0.11.1 → 0.11.2 (patch — release-infra fix only).

Made with [Cursor](https://cursor.com)